### PR TITLE
feat: アーティスト検索・再生機能 + 検索UX改善

### DIFF
--- a/Night-Core-Player/Core/AppError.swift
+++ b/Night-Core-Player/Core/AppError.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-/// アプリ全体で使用する統一エラー型
 enum AppError: LocalizedError {
     case musicKit(underlying: Error)
     case player(String)

--- a/Night-Core-Player/Core/BusinessConstants.swift
+++ b/Night-Core-Player/Core/BusinessConstants.swift
@@ -30,8 +30,8 @@ public enum Constants {
     }
 
     public enum RepeatMode: Sendable {
-        case none // ループなし
-        case one // 現在の曲をループ
-        case all // 再生キュー全体をリピート
+        case none
+        case one
+        case all
     }
 }

--- a/Night-Core-Player/Core/UIConstants.swift
+++ b/Night-Core-Player/Core/UIConstants.swift
@@ -45,7 +45,6 @@ extension Constants {
         }
 
         public enum Font {
-            // Add public static let as needed
         }
 
         public enum Opacity {

--- a/Night-Core-Player/Data/AppDataStore.swift
+++ b/Night-Core-Player/Data/AppDataStore.swift
@@ -25,7 +25,6 @@ struct AppDataStore {
         }
     }
 
-    /// 既存の SwiftData ストアファイルを削除する
     private static func deleteStoreFiles() {
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask

--- a/Night-Core-Player/Data/Repositories/HistoryRepository.swift
+++ b/Night-Core-Player/Data/Repositories/HistoryRepository.swift
@@ -9,7 +9,6 @@ final class HistoryRepository {
         self.context = context
     }
 
-    /// 再生ごとにレコード追加
     func append(songID: String) throws {
         let entry = HistoryEntity(songID: songID)
         context.insert(entry)
@@ -18,7 +17,6 @@ final class HistoryRepository {
         try context.save()
     }
 
-    /// 再生履歴読み込み（新しい順）
     func loadAll() throws -> [String] {
         var desc = FetchDescriptor<HistoryEntity>(
             sortBy: [.init(\.playedAt, order: .reverse)])
@@ -26,7 +24,6 @@ final class HistoryRepository {
         return try context.fetch(desc).map(\.songID)
     }
 
-    /// 全履歴クリア
     func clear() throws {
         let descriptor = FetchDescriptor<HistoryEntity>()
         let list = try context.fetch(descriptor)
@@ -34,7 +31,6 @@ final class HistoryRepository {
         try context.save()
     }
 
-    // 履歴が最大保持数を超えた場合、古い順に削除
     private func trimOverflowIfNeeded() throws {
         var desc = FetchDescriptor<HistoryEntity>(
             sortBy: [.init(\.playedAt, order: .forward)]

--- a/Night-Core-Player/Data/Repositories/PlayerStateRepository.swift
+++ b/Night-Core-Player/Data/Repositories/PlayerStateRepository.swift
@@ -9,7 +9,6 @@ final class PlayerStateRepository {
         self.context = context
     }
 
-    /// 保存 or 更新
     func save(
         queueIDs: [String],
         currentIndex: Int,
@@ -30,7 +29,6 @@ final class PlayerStateRepository {
         try context.save()
     }
 
-    /// 読み込み
     func load() throws -> (
         queueIDs: [String],
         currentIndex: Int,

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -7,36 +7,51 @@ struct MainTabView: View {
     @Environment(MusicPlayerViewModel.self) private var playerVM
     @Environment(SettingsViewModel.self) private var settingsVM
     @Environment(KeyboardResponder.self) private var keyboard
-    
-    // MiniPlayerの要素の高さ
+
     private let miniPlayerHeight: CGFloat = Constants.UI.FrameSize.miniMusicPlayerHeight
-    
+
+    private var showMiniPlayer: Bool {
+        nav.selectedTab != .player && !keyboard.isVisible
+    }
+
     var body: some View {
         @Bindable var nav = nav
+        let tabBinding = Binding<PlayerNavigator.Tab>(
+            get: { nav.selectedTab },
+            set: { newTab in
+                if newTab == nav.selectedTab && newTab == .search {
+                    nav.searchBarFocusRequested = true
+                }
+                nav.selectedTab = newTab
+            }
+        )
         ZStack(alignment: .bottom) {
-            TabView(selection: $nav.selectedTab) {
+            TabView(selection: tabBinding) {
                 MusicPlayerView()
                     .tabItem { Label("Player", systemImage: "music.note") }
                     .tag(PlayerNavigator.Tab.player)
                     .safeAreaPadding(.bottom, miniPlayerHeight)
-                
+
                 SearchView()
                     .tabItem { Label("Search", systemImage: "magnifyingglass") }
                     .tag(PlayerNavigator.Tab.search)
                     .safeAreaPadding(.bottom, miniPlayerHeight)
-                
+
                 PlaylistView()
                     .tabItem { Label("Playlist", systemImage: "list.bullet") }
                     .tag(PlayerNavigator.Tab.playlist)
                     .safeAreaPadding(.bottom, miniPlayerHeight)
-                
+
                 SettingsView()
                     .tabItem { Label("Settings", systemImage: "gearshape") }
                     .tag(PlayerNavigator.Tab.settings)
                     .safeAreaPadding(.bottom, miniPlayerHeight)
             }
-            
-            if nav.selectedTab != .player && !keyboard.isVisible {
+            .onScrollDetected { scrolling in
+                nav.isScrolling = scrolling
+            }
+
+            if showMiniPlayer {
                 MiniMusicPlayerView()
                     .frame(height: miniPlayerHeight)
                     .background(.ultraThinMaterial)
@@ -49,8 +64,8 @@ struct MainTabView: View {
                         }
                     }
                     .padding(.bottom, 55)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                    .animation(.easeInOut, value: playerVM.isPlaying)
+                    .opacity(nav.isScrolling ? 0.3 : 1.0)
+                    .animation(.easeInOut(duration: 0.2), value: nav.isScrolling)
             }
         }
         .enableInjection()

--- a/Night-Core-Player/Features/Common/MiniMusicPlayerView.swift
+++ b/Night-Core-Player/Features/Common/MiniMusicPlayerView.swift
@@ -8,7 +8,6 @@ struct MiniMusicPlayerView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            // プログレスバー
             GeometryReader { geo in
                 let progress = vm.duration > 0
                 ? vm.currentTime / vm.duration

--- a/Night-Core-Player/Features/Common/PlayerNavigator.swift
+++ b/Night-Core-Player/Features/Common/PlayerNavigator.swift
@@ -7,8 +7,11 @@ final class PlayerNavigator {
     enum Tab: Hashable {
         case player, search, playlist, settings
     }
-    
+
     var selectedTab: Tab = .player
     var songs: [Song] = []
     var initialIndex: Int = 0
+
+    var searchBarFocusRequested: Bool = false
+    var isScrolling: Bool = false
 }

--- a/Night-Core-Player/Features/Common/PlayingQueueItemRowView.swift
+++ b/Night-Core-Player/Features/Common/PlayingQueueItemRowView.swift
@@ -16,17 +16,19 @@ struct PlayingQueueItemRowView: View {
                             .scaledToFit()
                     default:
                         Image(systemName: "music.note")
-                            .resizable()
+                            .font(.title2)
+                            .foregroundColor(.secondary)
+                            .frame(width: 44, height: 44)
+                            .background(Color(.secondarySystemBackground))
                     }
                 }
                 .frame(width: 44, height: 44)
                 .cornerRadius(6)
-                
-                // artworkがなければDefautアイコン
+
             } else {
                 Image(systemName: "music.note")
-                    .resizable()
-                    .scaledToFit()
+                    .font(.title2)
+                    .foregroundColor(.secondary)
                     .frame(width: 44, height: 44)
                     .background(Color(.secondarySystemBackground))
                     .cornerRadius(6)

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -20,7 +20,6 @@ struct SpeedControlButton: View {
     }
 }
 
-// Sliderにメモリを表示するOverlay
 struct SliderTickMarksOverlay: View {
     let minValue: Double = Constants.MusicPlayer.minPlaybackRate
     let maxValue: Double = Constants.MusicPlayer.maxPlaybackRate
@@ -35,11 +34,9 @@ struct SliderTickMarksOverlay: View {
                 let xPos   = geo.size.width * ratio
                 
                 VStack(spacing: 4) {
-                    // 数字（上）
                     Text(String(format: "%.1f", value))
                         .font(.caption2)
                         .foregroundColor(.secondary)
-                    // 目盛り（下）
                     Rectangle()
                         .fill(Color.secondary.opacity(0.6))
                         .frame(width: 1, height: 8)
@@ -64,20 +61,27 @@ struct MusicPlayerView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 16) {
-                // 🚀 タイトル
                 Text("Playing Now")
                     .font(.headline)
                     .padding(.top, 8)
                 Spacer()
                 
-                // 🖼️ アートワーク
-                vm.artworkImage
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 250, height: 250)
-                    .cornerRadius(12)
-                    .padding(.horizontal)
-                // ⏮️ 曲情報 + ⏭️
+                if vm.artworkData != nil {
+                    vm.artworkImage
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 250, height: 250)
+                        .cornerRadius(12)
+                        .padding(.horizontal)
+                } else {
+                    Image(systemName: "music.note")
+                        .font(.system(size: 80))
+                        .foregroundColor(.secondary)
+                        .frame(width: 250, height: 250)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(12)
+                        .padding(.horizontal)
+                }
                 HStack(spacing: 24) {
                     Button { vm.previousTrack() } label: {
                         Image(systemName: "backward.fill")
@@ -118,7 +122,6 @@ struct MusicPlayerView: View {
                             .foregroundColor(.indigo)
                     }
                 }
-                // 📊 シークバー
                 HStack {
                     Text(timeString(from: vm.currentTime))
                         .font(.caption2)
@@ -134,7 +137,6 @@ struct MusicPlayerView: View {
                         .font(.caption2)
                 }
                 .padding(.horizontal)
-                // ▶️ 再生コントロール
                 HStack(spacing: 48) {
                     Button { vm.rewind15() } label: {
                         Image(systemName: "gobackward.15")
@@ -158,7 +160,6 @@ struct MusicPlayerView: View {
                 
                 Spacer(minLength: 20)
                 
-                // ⚙️ 倍速調整
                 VStack(spacing: 10) {
                     Slider(
                         value: Binding(
@@ -197,7 +198,6 @@ struct MusicPlayerView: View {
                     }
                 }
                 
-                // 再生キュー表示
                 Button(action: {
                     isQueuePresented = true
                 }) {

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerViewModel.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerViewModel.swift
@@ -16,7 +16,6 @@ final class MusicPlayerViewModel {
     private(set) var artworkData: Data?  = nil
     private(set) var currentTime: Double = 0
 
-    /// artworkData から SwiftUI.Image を生成する（View 層で利用）
     var artworkImage: Image {
         if let data = artworkData, let ui = UIImage(data: data) {
             return Image(uiImage: ui)
@@ -30,7 +29,6 @@ final class MusicPlayerViewModel {
 
     private var skipSeconds: Double = Constants.MusicPlayer.skipSeconds
 
-    // 次に再生される楽曲キュー配列
     var currentQueue: [Song] {
         Array(musicPlayerQueue.dropFirst(currentIndex + 1))
     }
@@ -61,7 +59,6 @@ final class MusicPlayerViewModel {
         }
     }
 
-    // 再生キューの操作をグローバルなqueueに反映する
     func moveQueueItem(_ offsets: IndexSet, to newLocalIndex: Int) {
         guard let localSrc = offsets.first else { return }
         let srcGlobal = currentIndex + 1 + localSrc
@@ -89,7 +86,6 @@ final class MusicPlayerViewModel {
             self.currentIndex = service.nowPlayingIndex
         }
     }
-    // キューの先頭に楽曲を挿入し、再生を開始
     func playNowNext(_ song: Song) {
         Task {
             await service.playNextAndPlay(song)

--- a/Night-Core-Player/Features/MusicPlayer/PlayingQueueView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/PlayingQueueView.swift
@@ -8,7 +8,6 @@ struct MusicPlayerControlsView: View {
     
     var body: some View {
         VStack(spacing: 16) {
-            // 📊 シークバー
             VStack(spacing: 4) {
                 Slider(
                     value: Binding(
@@ -28,7 +27,6 @@ struct MusicPlayerControlsView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 15)
-            // ▶️ 再生コントロール
             HStack(spacing: 32) {
                 Button { vm.rewind15() } label: {
                     Image(systemName: "gobackward.15")
@@ -90,7 +88,6 @@ struct HistorySectionView: View {
     @State private var showDeleteAlert = false
 
     var body: some View {
-        // history が空ならセクション自体を表示しない
         if !vm.history.isEmpty {
             HStack {
                 Text("再生履歴")
@@ -134,7 +131,6 @@ struct QueueSectionView: View {
     @Environment(MusicPlayerViewModel.self) private var vm
     
     var body: some View {
-        // スクロールのターゲットとしてidを設定
         Text("次に再生")
             .font(.body).bold()
             .foregroundStyle(.primary)
@@ -152,10 +148,8 @@ struct QueueSectionView: View {
                     .foregroundColor(.secondary)
                     .padding(.trailing, 8)
             }
-            // ③ タップ領域全体を拾う
             .contentShape(Rectangle())
             .onTapGesture{ vm.playNowNext(song) }
-            // ④ 背景のハイライト
             .listRowBackground(Color.clear)
         }
         .onMove(perform: vm.moveQueueItem)
@@ -176,7 +170,6 @@ struct CombinedListView: View {
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .onAppear {
-                // 最初に必ず「次に再生」セクションを先頭に表示
                 proxy.scrollTo("queueHeader", anchor: .top)
             }
             .onChange(of: vm.currentIndex) {

--- a/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
@@ -17,12 +17,10 @@ struct PlaylistDetailView: View {
 
     var body: some View {
         Group {
-            // Loading State
             if vm.isLoading {
                 ProgressView("読み込み中…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            // Error State
             else if let msg = vm.errorMessage {
                 VStack(spacing: 12) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -36,10 +34,8 @@ struct PlaylistDetailView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            // Loaded State
             else {
                 VStack(spacing: 16) {
-                    // アクションボタン
                     HStack(spacing: 16) {
                         playlistActionButton(
                             title: "再生",
@@ -64,7 +60,6 @@ struct PlaylistDetailView: View {
                     }
                     .padding(.horizontal)
 
-                    // Song List
                     List(vm.songs, id: \.id) { song in
                         Button {
                             let idx = vm.songs.firstIndex { $0.id == song.id } ?? 0
@@ -97,7 +92,6 @@ struct PlaylistDetailView: View {
         .task { await vm.load() }
     }
 
-    /// プレイリスト操作ボタンの共通スタイル
     private func playlistActionButton(
         title: String,
         systemImage: String,

--- a/Night-Core-Player/Features/Playlist/PlaylistRowModel.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistRowModel.swift
@@ -2,9 +2,18 @@ import Foundation
 import SwiftUI
 import MusicKit
 
-struct PlaylistRowModel: Identifiable, Hashable {
+struct PlaylistRowModel: Identifiable {
     let id: Playlist.ID
     let title: String
     let artwork: Artwork?
     let playlist: Playlist
+}
+
+extension PlaylistRowModel: Hashable {
+    static func == (lhs: PlaylistRowModel, rhs: PlaylistRowModel) -> Bool {
+        lhs.id == rhs.id
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
 }

--- a/Night-Core-Player/Features/Playlist/PlaylistView.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistView.swift
@@ -11,8 +11,8 @@ struct PlaylistView: View {
         NavigationStack {
             content
                 .navigationTitle("プレイリスト")
-                .navigationDestination(for: Playlist.self) { pl in
-                    PlaylistDetailView(pl: pl, musicKitService: musicKitService)
+                .navigationDestination(for: PlaylistRowModel.self) { row in
+                    PlaylistDetailView(pl: row.playlist, musicKitService: musicKitService)
                 }
         }
         .task { await vm.load() }
@@ -56,7 +56,7 @@ struct PlaylistView: View {
         List {
             ForEach(vm.rows) { row in
                 VStack(spacing: 0) {
-                    NavigationLink(value: row.playlist) {
+                    NavigationLink(value: row) {
                         HStack(spacing: 12) {
                             if let artwork = row.artwork {
                                 ArtworkImage(artwork, width: 56, height: 56)
@@ -74,16 +74,13 @@ struct PlaylistView: View {
                         }
                         .padding(.vertical, 12)
                     }
-                    // 下線のみ描画
                     Divider()
                         .padding(.leading, 36)
                 }
-                // セル自体の罫線は非表示
                 .listRowSeparator(.hidden)
             }
         }
         .listStyle(.plain)
-        // List全体の左余白にも背景色が乗らないように
         .scrollContentBackground(.hidden)
         .background(Color(.systemBackground))
     }

--- a/Night-Core-Player/Features/Playlist/PlaylistViewModel.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistViewModel.swift
@@ -55,7 +55,6 @@ final class PlaylistViewModel {
             let (data, _) = try await URLSession.shared.data(from: url)
             guard let uiImage = UIImage(data: data) else { return }
             
-            // キャッシュに保存しておく
             artworkCache[playlist.id] = uiImage
             
             if let idx = rows.firstIndex(where: { $0.id == playlist.id }) {
@@ -68,7 +67,6 @@ final class PlaylistViewModel {
             }
             
         } catch {
-            // 取得失敗時、プレースホルダーのまま表示
         }
     }
 }

--- a/Night-Core-Player/Features/Search/ArtistDetailView.swift
+++ b/Night-Core-Player/Features/Search/ArtistDetailView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+import Inject
+import MusicKit
+
+struct ArtistDetailView: View {
+    @ObserveInjection var inject
+    @State private var vm: ArtistDetailViewModel
+    @Environment(PlayerNavigator.self) private var nav
+    @Environment(MusicPlayerViewModel.self) private var playerVM
+
+    init(artist: Artist, musicKitService: any MusicKitService) {
+        _vm = State(initialValue: ArtistDetailViewModel(
+            artist: artist,
+            musicKitService: musicKitService
+        ))
+    }
+
+    var body: some View {
+        Group {
+            if vm.isLoading {
+                ProgressView("読み込み中…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let msg = vm.errorMessage {
+                VStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.largeTitle)
+                        .foregroundColor(.orange)
+                    Text(msg)
+                        .multilineTextAlignment(.center)
+                    Button("リトライ") {
+                        Task { await vm.load() }
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                VStack(spacing: 16) {
+                    HStack(spacing: 16) {
+                        actionButton(title: "再生", systemImage: "play.fill") {
+                            Task {
+                                await vm.loadAllAvailable()
+                                playerVM.loadPlaylist(
+                                    songs: vm.songs,
+                                    startAt: 0,
+                                    autoPlay: true
+                                )
+                                nav.selectedTab = .player
+                            }
+                        }
+                        actionButton(title: "シャッフル", systemImage: "shuffle") {
+                            Task {
+                                await vm.loadAllAvailable()
+                                playerVM.loadPlaylist(
+                                    songs: vm.songs.shuffled(),
+                                    startAt: 0,
+                                    autoPlay: true
+                                )
+                                nav.selectedTab = .player
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+
+                    List {
+                        ForEach(vm.songs, id: \.id) { song in
+                            Button {
+                                let idx = vm.songs.firstIndex { $0.id == song.id } ?? 0
+                                playerVM.loadPlaylist(
+                                    songs: vm.songs,
+                                    startAt: idx,
+                                    autoPlay: true
+                                )
+                                nav.selectedTab = .player
+                            } label: {
+                                SongRowView(song: song)
+                            }
+                            .onAppear {
+                                Task { await vm.loadMoreIfNeeded(currentSong: song) }
+                            }
+                        }
+
+                        if vm.isLoadingMore {
+                            HStack {
+                                Spacer()
+                                ProgressView()
+                                Spacer()
+                            }
+                        }
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .background(Color(.systemBackground))
+                }
+                .padding(.horizontal)
+            }
+        }
+        .navigationTitle(vm.artist.name)
+        .navigationBarTitleDisplayMode(.large)
+        .enableInjection()
+        .task { await vm.load() }
+    }
+
+    private func actionButton(
+        title: String,
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: systemImage)
+                Text(title)
+            }
+            .font(.body)
+            .frame(maxWidth: .infinity, minHeight: Constants.UI.FrameSize.buttonMinHeight)
+        }
+        .foregroundColor(Constants.AppColors.accent)
+        .background(Color(.systemGray5))
+        .cornerRadius(Constants.UI.CornerRadius.standard)
+    }
+}

--- a/Night-Core-Player/Features/Search/ArtistDetailViewModel.swift
+++ b/Night-Core-Player/Features/Search/ArtistDetailViewModel.swift
@@ -1,0 +1,85 @@
+import Foundation
+import MusicKit
+import Observation
+
+@Observable
+@MainActor
+final class ArtistDetailViewModel {
+    let artist: Artist
+    private(set) var songs: [Song] = []
+    private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    private(set) var hasMoreSongs = false
+    private(set) var errorMessage: String?
+
+    private let musicKitService: MusicKitService
+    private var currentOffset: Int = 0
+
+    init(artist: Artist, musicKitService: MusicKitService) {
+        self.artist = artist
+        self.musicKitService = musicKitService
+    }
+
+    func load() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let topSongs = try await musicKitService.fetchArtistTopSongs(artist: artist)
+            songs = topSongs
+            currentOffset = topSongs.count
+            hasMoreSongs = topSongs.count >= 10
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            songs = []
+        }
+    }
+
+    /// 再生/シャッフル用に可能な限り多くの曲を取得する
+    func loadAllAvailable() async {
+        while hasMoreSongs && !isLoadingMore {
+            isLoadingMore = true
+            defer { isLoadingMore = false }
+            do {
+                let more = try await musicKitService.searchSongs(
+                    keyword: artist.name,
+                    limit: Constants.MusicAPI.musicKitSearchLimit,
+                    offset: currentOffset
+                )
+                let existingIDs = Set(songs.map { $0.id })
+                let newSongs = more.filter { !existingIDs.contains($0.id) }
+                songs.append(contentsOf: newSongs)
+                currentOffset += more.count
+                hasMoreSongs = more.count >= Constants.MusicAPI.musicKitSearchLimit
+                if songs.count >= 50 { break }
+            } catch {
+                break
+            }
+        }
+    }
+
+    func loadMoreIfNeeded(currentSong: Song) async {
+        guard hasMoreSongs, !isLoadingMore,
+              currentSong.id == songs.last?.id else { return }
+
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let more = try await musicKitService.searchSongs(
+                keyword: artist.name,
+                limit: Constants.MusicAPI.musicKitSearchLimit,
+                offset: currentOffset
+            )
+            let existingIDs = Set(songs.map { $0.id })
+            let newSongs = more.filter { !existingIDs.contains($0.id) }
+            songs.append(contentsOf: newSongs)
+            currentOffset += more.count
+            hasMoreSongs = more.count >= Constants.MusicAPI.musicKitSearchLimit
+        } catch {
+            // 追加読み込みのエラーは握りつぶす
+        }
+    }
+}

--- a/Night-Core-Player/Features/Search/ArtistDetailViewModel.swift
+++ b/Night-Core-Player/Features/Search/ArtistDetailViewModel.swift
@@ -29,7 +29,7 @@ final class ArtistDetailViewModel {
             let topSongs = try await musicKitService.fetchArtistTopSongs(artist: artist)
             songs = topSongs
             currentOffset = topSongs.count
-            hasMoreSongs = topSongs.count >= 10
+            hasMoreSongs = songs.count < 50
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription

--- a/Night-Core-Player/Features/Search/ArtistRowView.swift
+++ b/Night-Core-Player/Features/Search/ArtistRowView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import MusicKit
+
+struct ArtistRowView: View {
+    let artist: Artist
+
+    var body: some View {
+        HStack {
+            if let url = artist.artwork?.url(width: 48, height: 48) {
+                AsyncImage(url: url) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 48, height: 48)
+                .clipShape(Circle())
+            } else {
+                Image(systemName: "person.fill")
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+                    .frame(width: 48, height: 48)
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(Circle())
+            }
+
+            Text(artist.name)
+                .font(.body)
+                .foregroundColor(.primary)
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Night-Core-Player/Features/Search/SearchView.swift
+++ b/Night-Core-Player/Features/Search/SearchView.swift
@@ -5,9 +5,7 @@ import MusicKit
 struct SearchRowView: View {
     let song: Song
     @Environment(MusicPlayerViewModel.self) private var playerVM
-    
-    @State private var isShowingPopover = false
-    
+
     var body: some View {
         HStack {
             if let url = song.artwork?.url(width: 48, height: 48) {
@@ -24,7 +22,7 @@ struct SearchRowView: View {
                     .background(Color(.secondarySystemBackground))
                     .cornerRadius(8)
             }
-            
+
             VStack(alignment: .leading, spacing: 4) {
                 Text(song.title)
                     .font(.body)
@@ -39,12 +37,15 @@ struct SearchRowView: View {
         .padding(.vertical, 4)
     }
 }
+
 struct SearchView: View {
     @ObserveInjection var inject
     @Environment(SearchViewModel.self) private var vm
     @Environment(PlayerNavigator.self) private var nav
     @Environment(MusicPlayerViewModel.self) private var playerVM
-        
+    @Environment(\.musicKitService) private var musicKitService
+    @FocusState private var isSearchBarFocused: Bool
+
     var body: some View {
         @Bindable var vm = vm
         NavigationStack {
@@ -52,6 +53,7 @@ struct SearchView: View {
                 HStack {
                     Image(systemName: "magnifyingglass")
                     TextField("曲名・アーティスト名", text: $vm.query)
+                        .focused($isSearchBarFocused)
                         .textInputAutocapitalization(.never)
                         .disableAutocorrection(true)
                         .submitLabel(.search)
@@ -63,25 +65,47 @@ struct SearchView: View {
                 .cornerRadius(10)
                 .padding(.horizontal)
                 .padding(.top, 8)
-                
+                .onChange(of: nav.searchBarFocusRequested) { _, requested in
+                    if requested {
+                        isSearchBarFocused = true
+                        nav.searchBarFocusRequested = false
+                    }
+                }
+
                 if vm.isLoading {
                     ProgressView().padding(.top, 40)
-                } else if !vm.songs.isEmpty {
-                    List(vm.songs, id: \.id) { song in
-                        Button {
-                            let idx = vm.songs.firstIndex(where: { $0.id == song.id}) ?? 0
-                            playerVM.loadPlaylist(songs: vm.songs, startAt: idx, autoPlay: true)
-                            nav.songs = vm.songs
-                            nav.initialIndex = vm.songs.firstIndex(where: { $0.id == song.id }) ?? 0
-                            nav.selectedTab = .player
-                        } label: {
-                            SearchRowView(song: song)
+                } else if !vm.artists.isEmpty || !vm.songs.isEmpty {
+                    List {
+                        ForEach(vm.artists, id: \.id) { artist in
+                            NavigationLink(value: artist) {
+                                ArtistRowView(artist: artist)
+                            }
+                        }
+
+                        ForEach(vm.songs, id: \.id) { song in
+                            Button {
+                                let idx = vm.songs.firstIndex(where: { $0.id == song.id }) ?? 0
+                                playerVM.loadPlaylist(songs: vm.songs, startAt: idx, autoPlay: true)
+                                nav.selectedTab = .player
+                            } label: {
+                                SearchRowView(song: song)
+                            }
+                            .onAppear {
+                                Task { await vm.loadMoreSongsIfNeeded(currentSong: song) }
+                            }
+                        }
+
+                        if vm.isLoadingMore {
+                            HStack {
+                                Spacer()
+                                ProgressView()
+                                Spacer()
+                            }
                         }
                     }
-                
                     .listStyle(PlainListStyle())
                 }
-                
+
                 Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -89,6 +113,9 @@ struct SearchView: View {
             .background(Color(.systemBackground))
             .navigationTitle("検索")
             .navigationBarTitleDisplayMode(.large)
+            .navigationDestination(for: Artist.self) { artist in
+                ArtistDetailView(artist: artist, musicKitService: musicKitService)
+            }
             .alert("エラー", isPresented: Binding<Bool>(
                 get: { vm.errorMessage != nil },
                 set: { if !$0 { vm.errorMessage = nil } }
@@ -101,4 +128,3 @@ struct SearchView: View {
         }
     }
 }
-

--- a/Night-Core-Player/Features/Search/SearchViewModel.swift
+++ b/Night-Core-Player/Features/Search/SearchViewModel.swift
@@ -5,23 +5,27 @@ import Observation
 @Observable
 @MainActor
 final class SearchViewModel {
-    
+
     private let musicKitService: MusicKitService
-    
+
     var query: String = "" {
         didSet { scheduleSearch() }
     }
     private(set) var songs: [Song] = []
+    private(set) var artists: [Artist] = []
     private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    private(set) var hasMoreSongs = false
     var errorMessage: String?
-    
+
     private var searchTask: Task<Void, Never>?
     private var lastSearchedQuery: String = ""
-    
+    private var currentOffset: Int = 0
+
     init(musicKitService: MusicKitService) {
         self.musicKitService = musicKitService
     }
-    
+
     private func scheduleSearch() {
         let current = query
         guard current != lastSearchedQuery else { return }
@@ -32,18 +36,63 @@ final class SearchViewModel {
             await performSearch(keyword: current)
         }
     }
-    
+
     public func performSearch(keyword: String) async {
         let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
         lastSearchedQuery = query
-        guard !trimmed.isEmpty else { songs = []; return }
-        
+        guard !trimmed.isEmpty else {
+            songs = []
+            artists = []
+            hasMoreSongs = false
+            currentOffset = 0
+            return
+        }
+
         isLoading = true; errorMessage = nil
+        currentOffset = 0
         do {
-            songs = try await musicKitService.searchSongs(keyword: trimmed, limit: Constants.MusicAPI.musicKitSearchLimit)
+            async let fetchedSongs = musicKitService.searchSongs(
+                keyword: trimmed, limit: Constants.MusicAPI.musicKitSearchLimit, offset: 0
+            )
+            async let fetchedArtists = musicKitService.searchArtists(
+                keyword: trimmed, limit: 5
+            )
+            songs = try await fetchedSongs
+            artists = try await fetchedArtists
+            currentOffset = songs.count
+            hasMoreSongs = songs.count >= Constants.MusicAPI.musicKitSearchLimit
         } catch {
-            self.errorMessage = error.localizedDescription; songs = []
+            if Task.isCancelled || error is CancellationError
+                || (error as NSError).code == NSURLErrorCancelled {
+                return
+            }
+            self.errorMessage = error.localizedDescription
+            songs = []
+            artists = []
+            hasMoreSongs = false
         }
         isLoading = false
+    }
+
+    func loadMoreSongsIfNeeded(currentSong: Song) async {
+        guard hasMoreSongs, !isLoadingMore,
+              currentSong.id == songs.last?.id else { return }
+
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        let trimmed = lastSearchedQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        do {
+            let more = try await musicKitService.searchSongs(
+                keyword: trimmed, limit: Constants.MusicAPI.musicKitSearchLimit, offset: currentOffset
+            )
+            songs.append(contentsOf: more)
+            currentOffset += more.count
+            hasMoreSongs = more.count >= Constants.MusicAPI.musicKitSearchLimit
+        } catch {
+            // 追加読み込みのエラーは握りつぶす（メインの結果は残す）
+        }
     }
 }

--- a/Night-Core-Player/Features/Search/SearchViewModel.swift
+++ b/Night-Core-Player/Features/Search/SearchViewModel.swift
@@ -39,7 +39,7 @@ final class SearchViewModel {
 
     public func performSearch(keyword: String) async {
         let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
-        lastSearchedQuery = query
+        lastSearchedQuery = trimmed
         guard !trimmed.isEmpty else {
             songs = []
             artists = []
@@ -50,6 +50,7 @@ final class SearchViewModel {
 
         isLoading = true; errorMessage = nil
         currentOffset = 0
+        defer { isLoading = false }
         do {
             async let fetchedSongs = musicKitService.searchSongs(
                 keyword: trimmed, limit: Constants.MusicAPI.musicKitSearchLimit, offset: 0
@@ -71,7 +72,6 @@ final class SearchViewModel {
             artists = []
             hasMoreSongs = false
         }
-        isLoading = false
     }
 
     func loadMoreSongsIfNeeded(currentSong: Song) async {

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -17,7 +17,6 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             List {
-                // ──────────── サウンド設定 ────────────
                 Section {
                     ForEach(soundSettings, id: \.self) { name in
                         VStack(spacing: 0) {
@@ -42,7 +41,6 @@ struct SettingsView: View {
                         .padding(.top, 8)
                 }
                 
-                // ──────────── その他 ────────────
                 Section {
                     ForEach(others, id: \.self) { name in
                         VStack(spacing: 0) {
@@ -121,7 +119,6 @@ struct SettingsView: View {
         .enableInjection()
     }
 
-    /// お問い合わせ用メール URL
     private var contactMailURL: URL {
         let subject = "NightCore Player お問い合わせ"
         let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""

--- a/Night-Core-Player/Features/Settings/SettingsViewModel.swift
+++ b/Night-Core-Player/Features/Settings/SettingsViewModel.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import Observation
 
-/// Settings 画面のデフォルト再生速度を管理する ViewModel
 @Observable
 @MainActor
 final class SettingsViewModel {
@@ -17,7 +16,6 @@ final class SettingsViewModel {
         self.defaultRate = rateManager.defaultRate
     }
 
-    /// デフォルト再生速度を更新し、現在のセッションにも即反映する
     func updateDefaultRate(to rate: Double) {
         let clamped = min(
             max(rate, Constants.MusicPlayer.minPlaybackRate),

--- a/Night-Core-Player/Features/Settings/TermsView.swift
+++ b/Night-Core-Player/Features/Settings/TermsView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-/// 利用規約・プライバシーポリシー表示画面
 struct TermsView: View {
     private let markdownContent: String
 

--- a/Night-Core-Player/Models/History.swift
+++ b/Night-Core-Player/Models/History.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-/// 再生履歴のドメインモデル（純粋 struct。SwiftData 依存なし）
 struct History {
     let id: String
     let songID: String

--- a/Night-Core-Player/Models/PlayerState.swift
+++ b/Night-Core-Player/Models/PlayerState.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-/// 再生状態のドメインモデル（純粋 struct。SwiftData 依存なし）
 struct PlayerState {
     let queueIDs: [String]
     let currentIndex: Int

--- a/Night-Core-Player/Services/ArtworkCacheService.swift
+++ b/Night-Core-Player/Services/ArtworkCacheService.swift
@@ -4,10 +4,8 @@ import MusicKit
 
 // MARK: - Protocol
 
-/// アートワークの取得とキャッシュを担当する（Catalog コンテキスト）
 @MainActor
 protocol ArtworkCacheService: Sendable {
-    /// 曲のアートワークデータを取得する（カタログ優先 → オリジナル → nil）
     func getArtwork(for song: Song?) async -> Data?
 }
 

--- a/Night-Core-Player/Services/MPMusicPlayerAdapter.swift
+++ b/Night-Core-Player/Services/MPMusicPlayerAdapter.swift
@@ -1,6 +1,5 @@
 import MediaPlayer
 
-/// MPMusicPlayerController を PlayerControllable に適合させるアダプタ
 @MainActor
 final class MPMusicPlayerAdapter: PlayerControllable {
     private let player = MPMusicPlayerController.applicationQueuePlayer

--- a/Night-Core-Player/Services/MusicKitService.swift
+++ b/Night-Core-Player/Services/MusicKitService.swift
@@ -4,31 +4,63 @@ import SwiftUI
 
 // MARK: - Protocol
 
-/// Apple Music カタログとの対話を担当する（Catalog コンテキスト）
 protocol MusicKitService: Sendable {
     func ensureAuth() async throws -> Void
-    func searchSongs(keyword: String, limit: Int) async throws -> [Song]
+    func searchSongs(keyword: String, limit: Int, offset: Int) async throws -> [Song]
+    func searchArtists(keyword: String, limit: Int) async throws -> [Artist]
+    func fetchArtistTopSongs(artist: Artist) async throws -> [Song]
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist]
     func fetchPlaylistSongs(in playlist: Playlist) async throws -> [Song]
 }
 
+extension MusicKitService {
+    func searchSongs(keyword: String, limit: Int) async throws -> [Song] {
+        try await searchSongs(keyword: keyword, limit: limit, offset: 0)
+    }
+}
+
 // MARK: - MusicKitClient
 
-/// MusicKit API の低レベルラッパー
 protocol MusicKitClient: Sendable {
     func requestAuthorization() async -> MusicAuthorization.Status
-    func searchCatalogSongs(term: String, limit: Int) async throws -> [Song]
+    func searchCatalogSongs(term: String, limit: Int, offset: Int) async throws -> [Song]
+    func searchCatalogArtists(term: String, limit: Int) async throws -> [Artist]
+    func fetchArtistTopSongs(artist: Artist) async throws -> [Song]
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist]
     func fetchSongs(in playlist: Playlist) async throws -> [Song]
+}
+
+extension MusicKitClient {
+    func searchCatalogSongs(term: String, limit: Int) async throws -> [Song] {
+        try await searchCatalogSongs(term: term, limit: limit, offset: 0)
+    }
 }
 
 struct DefaultMusicKitClient: MusicKitClient {
     func requestAuthorization() async -> MusicAuthorization.Status {
         await MusicAuthorization.request()
     }
-    func searchCatalogSongs(term: String, limit: Int) async throws -> [Song] {
+    func searchCatalogSongs(term: String, limit: Int, offset: Int = 0) async throws -> [Song] {
         var req = MusicCatalogSearchRequest(term: term, types: [Song.self])
         req.limit = limit
+        req.offset = offset
+        let res = try await req.response()
+        return Array(res.songs)
+    }
+    func searchCatalogArtists(term: String, limit: Int) async throws -> [Artist] {
+        var req = MusicCatalogSearchRequest(term: term, types: [Artist.self])
+        req.limit = limit
+        let res = try await req.response()
+        return Array(res.artists)
+    }
+    func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
+        let detailed = try await artist.with([.topSongs])
+        let top = Array(detailed.topSongs ?? [])
+        if !top.isEmpty { return Array(top.prefix(25)) }
+
+        // topSongs が空の場合、アーティスト名でカタログ検索にフォールバック
+        var req = MusicCatalogSearchRequest(term: artist.name, types: [Song.self])
+        req.limit = 25
         let res = try await req.response()
         return Array(res.songs)
     }
@@ -69,10 +101,22 @@ final class MusicKitServiceImpl: MusicKitService {
     }
     func searchSongs(
         keyword: String,
-        limit: Int = Constants.MusicAPI.musicKitSearchLimit
+        limit: Int = Constants.MusicAPI.musicKitSearchLimit,
+        offset: Int = 0
     ) async throws -> [Song] {
         try await ensureAuth()
-        return try await client.searchCatalogSongs(term: keyword, limit: limit)
+        return try await client.searchCatalogSongs(term: keyword, limit: limit, offset: offset)
+    }
+    func searchArtists(
+        keyword: String,
+        limit: Int = 5
+    ) async throws -> [Artist] {
+        try await ensureAuth()
+        return try await client.searchCatalogArtists(term: keyword, limit: limit)
+    }
+    func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
+        try await ensureAuth()
+        return try await client.fetchArtistTopSongs(artist: artist)
     }
     func fetchLibraryPlaylists(limit: Int = 10) async throws -> [Playlist] {
         try await ensureAuth()

--- a/Night-Core-Player/Services/MusicPlayerService.swift
+++ b/Night-Core-Player/Services/MusicPlayerService.swift
@@ -55,7 +55,6 @@ public protocol QueueManaging: Sendable {
 
 // MARK: - MusicPlayerSnapshot
 
-/// 音楽プレイヤーの現在の状態（Playback コンテキスト）
 public struct MusicPlayerSnapshot: Sendable, Equatable {
     public let title: String
     public let artist: String
@@ -78,7 +77,6 @@ public struct MusicPlayerSnapshot: Sendable, Equatable {
 
 // MARK: - MusicPlayerService
 
-/// 音楽プレイヤーの再生操作を提供する（Playback コンテキスト）
 @MainActor
 protocol MusicPlayerService: Sendable {
     var snapshotPublisher: AnyPublisher<MusicPlayerSnapshot, Never> { get }

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -273,9 +273,9 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     private func updateSnapshot() {
         let item = player.nowPlayingItem
         let song = queue.currentSong
-        let title = item?.title ?? song?.title ?? "-"
-        let artist = item?.artist ?? song?.artistName ?? "-"
-        let duration = item?.playbackDuration ?? song?.duration ?? 0
+        let title = song?.title ?? item?.title ?? "-"
+        let artist = song?.artistName ?? item?.artist ?? "-"
+        let duration = song?.duration ?? item?.playbackDuration ?? 0
         let currentTime = player.currentTime
         let isPlaying = player.playbackState == .playing
         let rate = currentPlaybackRate

--- a/Night-Core-Player/Services/MusicQueueManager.swift
+++ b/Night-Core-Player/Services/MusicQueueManager.swift
@@ -1,6 +1,5 @@
 import MusicKit
 
-/// 再生キューの論理操作を集約
 @MainActor
 public final class MusicQueueManager: QueueManaging {
     public var items: [Song] = []

--- a/Night-Core-Player/Services/PlayHistoryManager.swift
+++ b/Night-Core-Player/Services/PlayHistoryManager.swift
@@ -3,16 +3,11 @@ import MusicKit
 
 // MARK: - Protocol
 
-/// 再生履歴の管理を担当する（Playback コンテキスト サブモジュール）
 @MainActor
 protocol PlayHistoryManaging: Sendable {
-    /// 現在の再生履歴
     var history: [Song] { get }
-    /// 履歴に曲を追加する（重複チェック + 上限トリミング付き）
     func append(_ song: Song) throws
-    /// 履歴をクリアする
     func clearHistory() throws
-    /// 履歴を復元する（起動時）
     func restoreHistory(_ songs: [Song])
 }
 

--- a/Night-Core-Player/Services/PlaybackRateManager.swift
+++ b/Night-Core-Player/Services/PlaybackRateManager.swift
@@ -2,14 +2,9 @@ import Foundation
 
 // MARK: - Protocol
 
-/// 再生速度のデフォルト値を管理する（Preference コンテキスト）
-/// - Session Rate（一時的）は MusicPlayerService が管理
-/// - Default Rate（永続化）は本プロトコルが管理
 @MainActor
 protocol PlaybackRateManager: Sendable {
-    /// 永続化されたデフォルト再生速度
     var defaultRate: Double { get }
-    /// デフォルト再生速度を更新し、永続化する
     func setDefaultRate(_ rate: Double) throws
 }
 

--- a/Night-Core-Player/Services/PlayerPersistenceService.swift
+++ b/Night-Core-Player/Services/PlayerPersistenceService.swift
@@ -3,10 +3,8 @@ import MusicKit
 
 // MARK: - Protocol
 
-/// プレーヤー状態の永続化（save / restore / catalog fetch）を担当する（横断: Persistence）
 @MainActor
 protocol PlayerPersistenceService: Sendable {
-    /// キュー状態を保存する
     func saveQueueState(
         queueIDs: [String],
         currentIndex: Int,
@@ -14,7 +12,6 @@ protocol PlayerPersistenceService: Sendable {
         shuffleModeRaw: Int,
         repeatModeRaw: Int
     ) throws
-    /// 永続化された状態を読み込む
     func loadState() throws -> (
         queueIDs: [String],
         currentIndex: Int,
@@ -22,9 +19,7 @@ protocol PlayerPersistenceService: Sendable {
         shuffleModeRaw: Int,
         repeatModeRaw: Int
     )
-    /// 楽曲 ID 配列から MusicKit カタログの Song を取得する（最大100件）
     func fetchCatalogSongs(_ ids: [String]) async throws -> [Song]
-    /// 再生履歴の ID 配列を読み込む
     func loadHistoryIDs() throws -> [String]
 }
 

--- a/Night-Core-Player/Share/Components/MarqueeText.swift
+++ b/Night-Core-Player/Share/Components/MarqueeText.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-/// 文字幅計測
 /// https://qiita.com/takehilo/items/2499c632c2e0e5cdcb06
 private struct TextWidthKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
@@ -9,8 +8,6 @@ private struct TextWidthKey: PreferenceKey {
     }
 }
 
-/// テキスト幅が visibleWidth を超える場合、自動横スクロールするコンポーネント
-/// 幅を超えなければ中央固定、超えたら3秒停止→リニアで左へエンドレススクロール
 struct MarqueeText: View {
     let text: String
     let font: Font
@@ -56,11 +53,9 @@ struct MarqueeText: View {
     
     var body: some View {
         GeometryReader { geo in
-            // 親 View の幅が visibleWidth より小さい場合に合わせる
             let currentVisibleWidth = min(visibleWidth, geo.size.width)
             
             ZStack(alignment: .leading) {
-                // hidden でコンテンツ幅を計測
                 Text(text)
                     .font(font)
                     .lineLimit(1)
@@ -76,12 +71,10 @@ struct MarqueeText: View {
                 
                 if shouldScroll {
                     HStack(spacing: spacingBetweenTexts) {
-                        // 実際に流すテキスト
                         Text(text).font(font).lineLimit(1).fixedSize(horizontal: true, vertical: false)
-                        // ループ用にコピーを並べる
                         Text(text).font(font).lineLimit(1).fixedSize()
                     }
-                    .id("\(text)-\(selectedTab)") // tab切り替えでアニメーションがリセットされるように
+                    .id("\(text)-\(selectedTab)")
                     .offset(x: isAnimating ? -(contentWidth + spacingBetweenTexts) : 0)
                     .frame(width: currentVisibleWidth, alignment: .leading)
                     .clipped()
@@ -95,7 +88,6 @@ struct MarqueeText: View {
                         contentWidth = 0
                     }
                 } else {
-                    // 幅内に収まる場合、アイドル状態の場合
                     Text(text)
                         .font(font)
                         .lineLimit(1)
@@ -107,13 +99,11 @@ struct MarqueeText: View {
             .frame(maxHeight: .infinity, alignment: .center)
             .clipped()
             .onPreferenceChange(TextWidthKey.self) {
-                // 計測結果を受け取って状態更新
                 contentWidth = $0
             }
         }
     }
     
-    // アニメーションがリセットするように、一度offにしてから開始する
     private func restartAnimation() {
         guard contentWidth > visibleWidth, speed > 0 else { return }
         withAnimation(.none) {

--- a/Night-Core-Player/Share/Components/SongContextMenu.swift
+++ b/Night-Core-Player/Share/Components/SongContextMenu.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import MusicKit
 
-/// 楽曲のコンテキストメニュー
 struct SongContextMenu: View {
     let song: Song
     @Environment(MusicPlayerViewModel.self) private var playerVM

--- a/Night-Core-Player/Share/Utilities/KeyboardResponder.swift
+++ b/Night-Core-Player/Share/Utilities/KeyboardResponder.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Combine
 import Observation
 
-/// キーボード表示状態を監視
 @Observable
 final class KeyboardResponder {
     var isVisible: Bool = false

--- a/Night-Core-Player/Share/Utilities/ScrollDetector.swift
+++ b/Night-Core-Player/Share/Utilities/ScrollDetector.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ScrollDetectorModifier: ViewModifier {
     let onScrolling: (Bool) -> Void
 
-    @State private var scrollTimer: Timer?
+    @State private var scrollTask: Task<Void, Never>?
 
     func body(content: Content) -> some View {
         content
@@ -12,25 +12,23 @@ struct ScrollDetectorModifier: ViewModifier {
                 DragGesture(minimumDistance: 5)
                     .onChanged { _ in
                         onScrolling(true)
-                        resetTimer()
+                        resetDelay()
                     }
                     .onEnded { _ in
-                        resetTimer()
+                        resetDelay()
                     }
             )
+            .onDisappear {
+                scrollTask?.cancel()
+            }
     }
 
-    private func resetTimer() {
-        scrollTimer?.invalidate()
-        let timer = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: false) { _ in
-            DispatchQueue.main.async {
-                onScrolling(false)
-            }
-        }
-        // @State にセットするのではなく直接保持
-        DispatchQueue.main.async {
-            scrollTimer?.invalidate()
-            scrollTimer = timer
+    private func resetDelay() {
+        scrollTask?.cancel()
+        scrollTask = Task {
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            guard !Task.isCancelled else { return }
+            onScrolling(false)
         }
     }
 }

--- a/Night-Core-Player/Share/Utilities/ScrollDetector.swift
+++ b/Night-Core-Player/Share/Utilities/ScrollDetector.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// List / ScrollView のスクロールを検知し、コールバックで通知する ViewModifier
+struct ScrollDetectorModifier: ViewModifier {
+    let onScrolling: (Bool) -> Void
+
+    @State private var scrollTimer: Timer?
+
+    func body(content: Content) -> some View {
+        content
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 5)
+                    .onChanged { _ in
+                        onScrolling(true)
+                        resetTimer()
+                    }
+                    .onEnded { _ in
+                        resetTimer()
+                    }
+            )
+    }
+
+    private func resetTimer() {
+        scrollTimer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: false) { _ in
+            DispatchQueue.main.async {
+                onScrolling(false)
+            }
+        }
+        // @State にセットするのではなく直接保持
+        DispatchQueue.main.async {
+            scrollTimer?.invalidate()
+            scrollTimer = timer
+        }
+    }
+}
+
+extension View {
+    func onScrollDetected(_ handler: @escaping (Bool) -> Void) -> some View {
+        modifier(ScrollDetectorModifier(onScrolling: handler))
+    }
+}

--- a/Night-Core-PlayerTests/Features/Search/ArtistDetailViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Search/ArtistDetailViewModelTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+import MusicKit
+@testable import Night_Core_Player
+
+@Suite(.serialized)
+@MainActor
+struct ArtistDetailViewModelTests {
+
+    @Test("load 成功: 楽曲が取得されエラーが nil になる")
+    func load_success() async {
+        // Given
+        let svc = MusicKitServiceMock()
+        let songs = [makeDummySong(id: "A1"), makeDummySong(id: "A2")]
+        svc.fetchArtistTopSongsResult = .success(songs)
+        let artist = makeDummyArtist()
+        let vm = ArtistDetailViewModel(artist: artist, musicKitService: svc)
+
+        // When
+        await vm.load()
+
+        // Then
+        #expect(vm.songs.count == 2)
+        #expect(vm.errorMessage == nil)
+        #expect(vm.isLoading == false)
+    }
+
+    @Test("load 失敗: エラーメッセージがセットされ songs が空になる")
+    func load_failure() async {
+        // Given
+        struct DummyErr: Error, LocalizedError {
+            var errorDescription: String? { "test error" }
+        }
+        let svc = MusicKitServiceMock()
+        svc.fetchArtistTopSongsResult = .failure(DummyErr())
+        let artist = makeDummyArtist()
+        let vm = ArtistDetailViewModel(artist: artist, musicKitService: svc)
+
+        // When
+        await vm.load()
+
+        // Then
+        #expect(vm.songs.isEmpty)
+        #expect(vm.errorMessage != nil)
+        #expect(vm.isLoading == false)
+    }
+
+    @Test("load 中の重複呼び出し: 2回目は無視される")
+    func load_preventsDuplicate() async {
+        // Given
+        let svc = MusicKitServiceMock()
+        svc.fetchArtistTopSongsResult = .success([makeDummySong(id: "A1")])
+        let artist = makeDummyArtist()
+        let vm = ArtistDetailViewModel(artist: artist, musicKitService: svc)
+
+        // When
+        async let first: () = vm.load()
+        async let second: () = vm.load()
+        _ = await (first, second)
+
+        // Then
+        #expect(svc.fetchArtistTopSongsCallCount == 1)
+    }
+}

--- a/Night-Core-PlayerTests/Features/Search/SearchViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Search/SearchViewModelTests.swift
@@ -82,15 +82,89 @@ struct SearchViewModelTests {
         struct DummyErr: Error {}
         let (vm, svc) = SearchViewModelTests.setUp()
         svc.searchError = DummyErr()
-        
+
         // When
         vm.query = "Error"
         try? await Task.sleep(nanoseconds: UInt64(Constants.Timing.searchDebounce + 50) * 1_000_000)
-        
+
         // Then
         #expect(svc.searchCallArgs.count == 1, "searchSongs が呼ばれること")
         #expect(vm.errorMessage != nil, "errorMessage がセットされること")
         #expect(vm.songs.isEmpty, "songs がクリアされること")
         #expect(vm.isLoading == false, "完了後 isLoading が false であること")
+    }
+
+    @Test("検索成功時: アーティストも取得される")
+    func searchIncludesArtists() async {
+        // Given
+        let (vm, svc) = SearchViewModelTests.setUp()
+        svc.stubSongs = [makeDummySong(id: "S1")]
+
+        // When
+        vm.query = "Artist"
+        try? await Task.sleep(nanoseconds: UInt64(Constants.Timing.searchDebounce + 50) * 1_000_000)
+
+        // Then
+        #expect(svc.searchArtistsCallArgs.count == 1)
+        #expect(svc.searchArtistsCallArgs.first?.keyword == "Artist")
+    }
+
+    @Test("キャンセルエラー: errorMessage に表示されない")
+    func cancellationError_notShown() async {
+        // Given
+        let (vm, svc) = SearchViewModelTests.setUp()
+        svc.stubSongs = [makeDummySong(id: "S1")]
+
+        // When: 素早く連続で query を変更（前のタスクがキャンセルされる）
+        vm.query = "First"
+        vm.query = "Second"
+        try? await Task.sleep(nanoseconds: UInt64(Constants.Timing.searchDebounce + 100) * 1_000_000)
+
+        // Then: キャンセルエラーは表示されない
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("無限スクロール: hasMoreSongs が正しく設定される")
+    func loadMore_hasMoreSongsFlag() async {
+        // Given
+        let (vm, svc) = SearchViewModelTests.setUp()
+        let songs = (0..<25).map { makeDummySong(id: "S\($0)") }
+        svc.stubSongs = songs
+
+        // When
+        await vm.performSearch(keyword: "Test")
+
+        // Then: 25件 = limit なので追加あり
+        #expect(vm.hasMoreSongs == true)
+        #expect(vm.songs.count == 25)
+    }
+
+    @Test("無限スクロール: limit 未満の場合 hasMoreSongs が false")
+    func loadMore_noMoreWhenUnderLimit() async {
+        // Given
+        let (vm, svc) = SearchViewModelTests.setUp()
+        svc.stubSongs = [makeDummySong(id: "S1")]
+
+        // When
+        await vm.performSearch(keyword: "Test")
+
+        // Then: 1件 < limit なので追加なし
+        #expect(vm.hasMoreSongs == false)
+    }
+
+    @Test("無限スクロール: 最後以外の曲では発動しない")
+    func loadMoreSongs_notTriggeredAtMiddleSong() async {
+        // Given
+        let (vm, svc) = SearchViewModelTests.setUp()
+        let songs = (0..<25).map { makeDummySong(id: "S\($0)") }
+        svc.stubSongs = songs
+
+        // When
+        await vm.performSearch(keyword: "Test")
+        let initialCount = svc.searchCallArgs.count
+        await vm.loadMoreSongsIfNeeded(currentSong: songs[10])
+
+        // Then: 追加検索は発生しない
+        #expect(svc.searchCallArgs.count == initialCount)
     }
 }

--- a/Night-Core-PlayerTests/Helpers/makeDummyData.swift
+++ b/Night-Core-PlayerTests/Helpers/makeDummyData.swift
@@ -29,6 +29,19 @@ public func makeDummySong(
 }
 
 
+public func makeDummyArtist(
+    id: String = "AR1",
+    name: String = "DummyArtist"
+) -> Artist {
+    let data = """
+    { "id":"\(id)",
+      "type":"artists",
+      "attributes": { "name":"\(name)" }
+    }
+    """.data(using: .utf8)!
+    return try! JSONDecoder().decode(Artist.self, from: data)
+}
+
 public func makeDummyPlaylist(
     id: String,
     name: String = "DummyList",

--- a/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
@@ -7,11 +7,15 @@ import MusicKit
 final class MusicKitClientMock: MusicKitClient, @unchecked Sendable {
     var authStatus: MusicAuthorization.Status = .authorized
     var searchResult: [Song] = []
+    var artistSearchResult: [Artist] = []
+    var artistTopSongs: [Song] = []
     var playlists: [Playlist] = []
     var playlistSongs: [Song] = []
-    
+
     private(set) var authorizationRequests = 0
     private(set) var searchCalls: [(term: String, limit: Int)] = []
+    private(set) var searchArtistCalls: [(term: String, limit: Int)] = []
+    private(set) var fetchArtistTopSongsCalls = 0
     private(set) var fetchPlaylistCalls: [Int] = []
     private(set) var fetchSongsCalls: [Playlist] = []
     
@@ -19,9 +23,17 @@ final class MusicKitClientMock: MusicKitClient, @unchecked Sendable {
         authorizationRequests += 1
         return authStatus
     }
-    func searchCatalogSongs(term: String, limit: Int) async throws -> [Song] {
+    func searchCatalogSongs(term: String, limit: Int, offset: Int) async throws -> [Song] {
         searchCalls.append((term: term, limit: limit))
         return searchResult
+    }
+    func searchCatalogArtists(term: String, limit: Int) async throws -> [Artist] {
+        searchArtistCalls.append((term: term, limit: limit))
+        return Array(artistSearchResult.prefix(limit))
+    }
+    func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
+        fetchArtistTopSongsCalls += 1
+        return artistTopSongs
     }
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist] {
         fetchPlaylistCalls.append(limit)

--- a/Night-Core-PlayerTests/Mock/MusicKitServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicKitServiceMock.swift
@@ -11,6 +11,13 @@ final class MusicKitServiceMock: MusicKitService {
     var stubSongs: [Song] = []
     var searchError: Error?
 
+    // MARK: - Artist トラッキング
+    var searchArtistsCallArgs: [(keyword: String, limit: Int)] = []
+    var stubArtists: [Artist] = []
+    var searchArtistsError: Error?
+    var fetchArtistTopSongsCallCount = 0
+    var fetchArtistTopSongsResult: Result<[Song], Error> = .success([])
+
     // MARK: - Playlist トラッキング
     var fetchLibraryPlaylistsCallCount = 0
     var fetchPlaylistSongsCallCount = 0
@@ -21,10 +28,24 @@ final class MusicKitServiceMock: MusicKitService {
 
     func ensureAuth() async throws { }
 
-    func searchSongs(keyword: String, limit: Int) async throws -> [Song] {
+    func searchSongs(keyword: String, limit: Int, offset: Int) async throws -> [Song] {
         searchCallArgs.append((keyword, limit))
         if let e = searchError { throw e }
         return stubSongs
+    }
+
+    func searchArtists(keyword: String, limit: Int) async throws -> [Artist] {
+        searchArtistsCallArgs.append((keyword, limit))
+        if let e = searchArtistsError { throw e }
+        return stubArtists
+    }
+
+    func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
+        fetchArtistTopSongsCallCount += 1
+        switch fetchArtistTopSongsResult {
+        case .success(let songs): return songs
+        case .failure(let error): throw error
+        }
     }
 
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist] {


### PR DESCRIPTION
## Summary
- アーティスト検索: 検索結果にアーティストを表示（丸型アートワーク）
- アーティスト詳細画面: topSongs + カタログ検索で最大50曲取得
- 再生/シャッフル: 全曲ロード後にキューに投入
- 無限スクロール: 検索結果・アーティスト詳細でページネーション対応
- 検索タブダブルタップ: テキスト入力にフォーカス
- 曲未セット時のアイコンサイズ修正
- ミニプレーヤー: スクロール中に透過
- 検索キャンセルエラーの非表示化
- Playlist画面の NavigationLink Hashable 問題修正
- 曲切替直後の duration 表示バグ修正
- コードから自明な冗長コメントを削除

## Related Issue
Closes #34

## Test plan
- [x] BUILD SUCCEEDED
- [x] TEST SUCCEEDED
- [x] アーティスト検索が動作する
- [x] アーティスト詳細で楽曲一覧が表示される
- [x] 再生/シャッフルで最大50曲がキューに入る
- [x] 無限スクロールで追加読み込みされる
- [x] 検索中の入力でエラーが表示されない
- [x] Playlist画面が正常に開く