### PR TITLE
fix: Issue #49 バグ修正・機能改善・UI改善

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,6 @@
+# NightCorePlayer overview
+- Purpose: iOS app to play Apple Music tracks in a Nightcore style (higher rate/pitch), with search, playlists, queue management, play history, and artwork cache.
+- Tech stack: Swift, SwiftUI, MusicKit + MediaPlayer, SwiftData, Combine, AVFoundation. Architecture is MVVM plus service layer with protocol-based DI.
+- Repo structure: `Night-Core-Player/` app sources (`Core`, `Models`, `Services`, `Data`, `Features`, `Extensions`, `Share`), `Night-Core-PlayerTests/` tests, `docs/specs/` design docs, `docs/memo/` investigations, `scripts/` utility scripts, `privacy-policy/` MkDocs site.
+- Entry point: `Night-Core-Player/App.swift` creates concrete services and injects view models into SwiftUI environment.
+- Current notable area: playback is centered in `Services/MusicPlayerServiceImpl.swift` with `MPMusicPlayerAdapter` over `MPMusicPlayerController.applicationQueuePlayer` and `MusicKitServiceImpl` for catalog/library access.

--- a/.serena/memories/style_and_conventions.md
+++ b/.serena/memories/style_and_conventions.md
@@ -1,0 +1,5 @@
+# Style and conventions
+- Keep existing Swift style: `@MainActor` on UI/service types that touch player state, protocol-based DI for services, concise comments, Japanese user-facing comments/messages.
+- Tests use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) and must follow Given/When/Then comments and `action_condition_expected` naming per `docs/specs/TESTING-STRATEGY.md`.
+- View logic should stay thin; behavior belongs in view models/services. Existing project docs explicitly avoid SwiftUI view tests and focus on service/viewmodel logic.
+- Maintain current code organization by feature/service rather than creating ad hoc files.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,10 @@
+# Suggested commands
+- List files: `fd <pattern> <path>`
+- Search text: `rg -n "<pattern>" Night-Core-Player Night-Core-PlayerTests docs`
+- Inspect history: `git log --oneline -- <path>` and `git blame -L start,end <path>`
+- Run targeted tests: `xcodebuild test -project Night-Core-Player.xcodeproj -scheme Night-Core-Player -destination 'id=<SIMULATOR_ID>' -only-testing:Night-Core-PlayerTests/MusicPlayerServiceTests -only-testing:Night-Core-PlayerTests/MusicKitServiceTests`
+- Show destinations: `xcodebuild -showdestinations -project Night-Core-Player.xcodeproj -scheme Night-Core-Player`
+- Real-device build: `xcodebuild -project Night-Core-Player.xcodeproj -scheme Night-Core-Player -configuration Debug -destination 'id=<DEVICE_ID>' -derivedDataPath ./.derivedData -allowProvisioningUpdates build`
+- Install to device: `xcrun devicectl device install app --device <DEVICE_ID> ./.derivedData/Build/Products/Debug-iphoneos/Night-Core-Player.app`
+- Launch on device: `xcrun devicectl device process launch --device <DEVICE_ID> --console MizuRyu.Night-Core-Player`
+- Search debug prints to remove later: `rg '🎵|⚠️.*print' Night-Core-Player/`

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,5 @@
+# Task completion checklist
+- Prefer lightweight verification first: targeted `xcodebuild test` for impacted suites.
+- For playback/library changes, verify on real device when possible because MusicKit/MediaPlayer behavior differs from simulator and mocks.
+- Summarize any environment-dependent risks separately from code changes, especially Apple Music authorization, subscription, and App Services configuration.
+- If debug logging was added during investigation, remove it before finalizing unless the user explicitly wants it kept.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,152 @@
+# the name by which the project can be referenced within Serena
+project_name: "NightCorePlayer"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- swift
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -53,11 +53,14 @@ struct MainTabView: View {
             .overlay(alignment: .bottom) {
                 // 検索タブ位置にオーバーレイしてタップ/長押しを検出
                 GeometryReader { geo in
-                    let tabWidth = geo.size.width / 4
+                    let tabs = PlayerNavigator.Tab.allCases
+                    let tabCount = max(1, CGFloat(tabs.count))
+                    let tabWidth = geo.size.width / tabCount
+                    let searchIndex = CGFloat(tabs.firstIndex(of: .search) ?? 1)
                     Color.clear
                         .frame(width: tabWidth, height: 50)
                         .contentShape(Rectangle())
-                        .position(x: tabWidth * 1.5, y: geo.size.height - 25)
+                        .position(x: tabWidth * (searchIndex + 0.5), y: geo.size.height - 25)
                         .onTapGesture {
                             if nav.selectedTab == .search {
                                 nav.searchBarFocusRequestID += 1

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -20,7 +20,7 @@ struct MainTabView: View {
             get: { nav.selectedTab },
             set: { newTab in
                 if newTab == nav.selectedTab && newTab == .search {
-                    nav.searchBarFocusRequested = true
+                    nav.searchBarFocusRequestID += 1
                 }
                 nav.selectedTab = newTab
             }
@@ -51,16 +51,23 @@ struct MainTabView: View {
                 nav.isScrolling = scrolling
             }
             .overlay(alignment: .bottom) {
-                // 検索タブ位置にオーバーレイして長押しジェスチャーを検出
+                // 検索タブ位置にオーバーレイしてタップ/長押しを検出
                 GeometryReader { geo in
                     let tabWidth = geo.size.width / 4
                     Color.clear
                         .frame(width: tabWidth, height: 50)
                         .contentShape(Rectangle())
                         .position(x: tabWidth * 1.5, y: geo.size.height - 25)
+                        .onTapGesture {
+                            if nav.selectedTab == .search {
+                                nav.searchBarFocusRequestID += 1
+                            } else {
+                                nav.selectedTab = .search
+                            }
+                        }
                         .onLongPressGesture(minimumDuration: 0.5) {
-                            nav.searchResetRequested = true
                             nav.selectedTab = .search
+                            nav.searchBarFocusRequestID += 1
                         }
                 }
             }

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -50,6 +50,20 @@ struct MainTabView: View {
             .onScrollDetected { scrolling in
                 nav.isScrolling = scrolling
             }
+            .overlay(alignment: .bottom) {
+                // 検索タブ位置にオーバーレイして長押しジェスチャーを検出
+                GeometryReader { geo in
+                    let tabWidth = geo.size.width / 4
+                    Color.clear
+                        .frame(width: tabWidth, height: 50)
+                        .contentShape(Rectangle())
+                        .position(x: tabWidth * 1.5, y: geo.size.height - 25)
+                        .onLongPressGesture(minimumDuration: 0.5) {
+                            nav.searchResetRequested = true
+                            nav.selectedTab = .search
+                        }
+                }
+            }
 
             if showMiniPlayer {
                 MiniMusicPlayerView()

--- a/Night-Core-Player/Features/Common/PlayerNavigator.swift
+++ b/Night-Core-Player/Features/Common/PlayerNavigator.swift
@@ -13,5 +13,6 @@ final class PlayerNavigator {
     var initialIndex: Int = 0
 
     var searchBarFocusRequested: Bool = false
+    var searchResetRequested: Bool = false
     var isScrolling: Bool = false
 }

--- a/Night-Core-Player/Features/Common/PlayerNavigator.swift
+++ b/Night-Core-Player/Features/Common/PlayerNavigator.swift
@@ -12,7 +12,7 @@ final class PlayerNavigator {
     var songs: [Song] = []
     var initialIndex: Int = 0
 
-    var searchBarFocusRequested: Bool = false
-    var searchResetRequested: Bool = false
+    var searchBarFocusRequestID: Int = 0
+    var pendingArtist: Artist? = nil
     var isScrolling: Bool = false
 }

--- a/Night-Core-Player/Features/Common/PlayerNavigator.swift
+++ b/Night-Core-Player/Features/Common/PlayerNavigator.swift
@@ -4,7 +4,7 @@ import MusicKit
 
 @Observable
 final class PlayerNavigator {
-    enum Tab: Hashable {
+    enum Tab: Hashable, CaseIterable {
         case player, search, playlist, settings
     }
 

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -51,6 +51,7 @@ struct MusicPlayerView: View {
     @ObserveInjection var inject
     @Environment(PlayerNavigator.self) private var nav
     @Environment(MusicPlayerViewModel.self) private var vm
+    @Environment(\.musicKitService) private var musicKitService
     @State private var isQueuePresented = false
     
     init() {
@@ -110,9 +111,12 @@ struct MusicPlayerView: View {
                             delayBeforeScroll: Constants.MarqueeText.defaultDelay,
                             selectedTab: nav.selectedTab
                         )
-                        .foregroundColor(.secondary)
+                        .foregroundColor(.indigo)
                         .frame(width: 100, height: subtitleHeight)
                         .clipped()
+                        .onTapGesture {
+                            navigateToArtist()
+                        }
                     }
                     Button { vm.nextTrack() } label: {
                         Image(systemName: "forward.fill")
@@ -197,9 +201,6 @@ struct MusicPlayerView: View {
                 }
                 
                 VStack(spacing: 4) {
-                    Image(systemName: "chevron.up")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
                     Image(systemName: "list.bullet")
                         .font(.title2)
                         .foregroundColor(.indigo)
@@ -229,7 +230,25 @@ struct MusicPlayerView: View {
                 )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .alert("再生エラー", isPresented: Binding<Bool>(
+                get: { vm.errorMessage != nil },
+                set: { if !$0 { vm.errorMessage = nil } }
+            )) {
+                Button("OK") { vm.errorMessage = nil }
+            } message: {
+                Text(vm.errorMessage ?? "")
+            }
             .enableInjection()
+        }
+    }
+
+    private func navigateToArtist() {
+        let artistName = vm.artist
+        guard artistName != "—" else { return }
+        Task {
+            guard let artist = try? await musicKitService.searchArtists(keyword: artistName, limit: 1).first else { return }
+            nav.pendingArtist = artist
+            nav.selectedTab = .search
         }
     }
 

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -244,7 +244,7 @@ struct MusicPlayerView: View {
 
     private func navigateToArtist() {
         let artistName = vm.artist
-        guard artistName != "—" else { return }
+        guard artistName != "—", artistName != "-" else { return }
         Task {
             guard let artist = try? await musicKitService.searchArtists(keyword: artistName, limit: 1).first else { return }
             nav.pendingArtist = artist

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -111,7 +111,7 @@ struct MusicPlayerView: View {
                             delayBeforeScroll: Constants.MarqueeText.defaultDelay,
                             selectedTab: nav.selectedTab
                         )
-                        .foregroundColor(.indigo)
+                        .foregroundColor(.secondary)
                         .frame(width: 100, height: subtitleHeight)
                         .clipped()
                         .onTapGesture {

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -66,22 +66,20 @@ struct MusicPlayerView: View {
                     .padding(.top, 8)
                 Spacer()
                 
-                if vm.artworkData != nil {
-                    vm.artworkImage
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 250, height: 250)
-                        .cornerRadius(12)
-                        .padding(.horizontal)
-                } else {
-                    Image(systemName: "music.note")
-                        .font(.system(size: 80))
-                        .foregroundColor(.secondary)
-                        .frame(width: 250, height: 250)
-                        .background(Color(.secondarySystemBackground))
-                        .cornerRadius(12)
-                        .padding(.horizontal)
-                }
+                artworkView
+                    .gesture(
+                        DragGesture(minimumDistance: 50)
+                            .onEnded { value in
+                                let horizontal = value.translation.width
+                                let vertical = value.translation.height
+                                guard abs(horizontal) > abs(vertical) else { return }
+                                if horizontal < -50 {
+                                    vm.nextTrack()
+                                } else if horizontal > 50 {
+                                    vm.previousTrack()
+                                }
+                            }
+                    )
                 HStack(spacing: 24) {
                     Button { vm.previousTrack() } label: {
                         Image(systemName: "backward.fill")
@@ -198,17 +196,28 @@ struct MusicPlayerView: View {
                     }
                 }
                 
-                Button(action: {
-                    isQueuePresented = true
-                }) {
-                    VStack(spacing: 4) {
-                        Image(systemName: "list.bullet")
-                            .font(.title2)
-                            .foregroundColor(.indigo)
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 30)
-                    .contentShape(Rectangle())
+                VStack(spacing: 4) {
+                    Image(systemName: "chevron.up")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Image(systemName: "list.bullet")
+                        .font(.title2)
+                        .foregroundColor(.indigo)
                 }
+                .frame(maxWidth: .infinity, minHeight: 30)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    isQueuePresented = true
+                }
+                .gesture(
+                    DragGesture(minimumDistance: 40)
+                        .onEnded { value in
+                            if value.translation.height < -40,
+                               abs(value.translation.height) > abs(value.translation.width) {
+                                isQueuePresented = true
+                            }
+                        }
+                )
             }
             .sheet(isPresented: $isQueuePresented) {
                 PlayingQueueView()
@@ -221,6 +230,26 @@ struct MusicPlayerView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .enableInjection()
+        }
+    }
+
+    @ViewBuilder
+    private var artworkView: some View {
+        if vm.artworkData != nil {
+            vm.artworkImage
+                .resizable()
+                .scaledToFit()
+                .frame(width: 250, height: 250)
+                .cornerRadius(12)
+                .padding(.horizontal)
+        } else {
+            Image(systemName: "music.note")
+                .font(.system(size: 80))
+                .foregroundColor(.secondary)
+                .frame(width: 250, height: 250)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(12)
+                .padding(.horizontal)
         }
     }
 }

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerViewModel.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerViewModel.swift
@@ -200,5 +200,12 @@ final class MusicPlayerViewModel {
                 self.history = self.service.playHistory
             }
             .store(in: &cancellables)
+
+        service.playbackErrorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.errorMessage = "再生するには Apple Music のサブスクリプションが必要です"
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Night-Core-Player/Features/MusicPlayer/PlayingQueueView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/PlayingQueueView.swift
@@ -251,11 +251,10 @@ struct PlayingQueueView: View {
                 }
                 Spacer()
             }
-            .padding(.top, 12)
-            .padding(.bottom, 4)
-            
+            .padding(.vertical, 8)
+
             MusicPlayerControlsView()
-                .padding(.vertical, 60)
+                .padding(.bottom, 16)
         }
         .background(Color(.systemBackground))
     }

--- a/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
@@ -21,6 +21,16 @@ struct PlaylistDetailView: View {
                 ProgressView("読み込み中…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+            else if vm.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "music.note.list")
+                        .font(.largeTitle)
+                        .foregroundColor(.secondary)
+                    Text("このプレイリストには表示できる曲がありません")
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
             else if let msg = vm.errorMessage {
                 VStack(spacing: 12) {
                     Image(systemName: "exclamationmark.triangle.fill")

--- a/Night-Core-Player/Features/Playlist/PlaylistDetailViewModel.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistDetailViewModel.swift
@@ -8,6 +8,7 @@ final class PlaylistDetailViewModel {
     let playlist: Playlist
     private(set) var songs: [Song] = []
     private(set) var isLoading = false
+    private(set) var isEmpty = false
     private(set) var errorMessage: String?
     
     private var musicKitService: MusicKitService
@@ -25,10 +26,22 @@ final class PlaylistDetailViewModel {
         
         do {
             songs = try await musicKitService.fetchPlaylistSongs(in: playlist)
+            isEmpty = songs.isEmpty
             errorMessage = nil
+        } catch let error as PlaylistSongsFetchError {
+            songs = []
+            switch error {
+            case .emptyPlaylist:
+                isEmpty = true
+                errorMessage = nil
+            case .tracksUnavailable:
+                isEmpty = false
+                errorMessage = error.localizedDescription
+            }
         } catch {
             errorMessage = error.localizedDescription
             songs = []
+            isEmpty = false
         }
     }
 }

--- a/Night-Core-Player/Features/Search/ArtistDetailViewModel.swift
+++ b/Night-Core-Player/Features/Search/ArtistDetailViewModel.swift
@@ -45,8 +45,8 @@ final class ArtistDetailViewModel {
 
         while hasMoreSongs {
             do {
-                let more = try await musicKitService.searchSongs(
-                    keyword: artist.name,
+                let more = try await musicKitService.fetchArtistSongs(
+                    artist: artist,
                     limit: Constants.MusicAPI.musicKitSearchLimit,
                     offset: currentOffset
                 )
@@ -70,8 +70,8 @@ final class ArtistDetailViewModel {
         defer { isLoadingMore = false }
 
         do {
-            let more = try await musicKitService.searchSongs(
-                keyword: artist.name,
+            let more = try await musicKitService.fetchArtistSongs(
+                artist: artist,
                 limit: Constants.MusicAPI.musicKitSearchLimit,
                 offset: currentOffset
             )

--- a/Night-Core-Player/Features/Search/SearchView.swift
+++ b/Night-Core-Player/Features/Search/SearchView.swift
@@ -71,6 +71,13 @@ struct SearchView: View {
                         nav.searchBarFocusRequested = false
                     }
                 }
+                .onChange(of: nav.searchResetRequested) { _, requested in
+                    if requested {
+                        vm.resetToHistory()
+                        isSearchBarFocused = false
+                        nav.searchResetRequested = false
+                    }
+                }
 
                 if vm.isLoading {
                     ProgressView().padding(.top, 40)

--- a/Night-Core-Player/Features/Search/SearchView.swift
+++ b/Night-Core-Player/Features/Search/SearchView.swift
@@ -45,10 +45,12 @@ struct SearchView: View {
     @Environment(MusicPlayerViewModel.self) private var playerVM
     @Environment(\.musicKitService) private var musicKitService
     @FocusState private var isSearchBarFocused: Bool
+    @State private var lastHandledSearchFocusRequestID: Int = 0
+    @State private var navigationPath = NavigationPath()
 
     var body: some View {
         @Bindable var vm = vm
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             VStack(spacing: 0) {
                 HStack {
                     Image(systemName: "magnifyingglass")
@@ -65,18 +67,15 @@ struct SearchView: View {
                 .cornerRadius(10)
                 .padding(.horizontal)
                 .padding(.top, 8)
-                .onChange(of: nav.searchBarFocusRequested) { _, requested in
-                    if requested {
-                        isSearchBarFocused = true
-                        nav.searchBarFocusRequested = false
-                    }
+                .onAppear {
+                    applyPendingSearchFocusIfNeeded()
                 }
-                .onChange(of: nav.searchResetRequested) { _, requested in
-                    if requested {
-                        vm.resetToHistory()
-                        isSearchBarFocused = false
-                        nav.searchResetRequested = false
-                    }
+                .onChange(of: nav.searchBarFocusRequestID) { _, _ in
+                    applyPendingSearchFocusIfNeeded()
+                }
+                .onChange(of: nav.selectedTab) { _, selectedTab in
+                    guard selectedTab == .search else { return }
+                    applyPendingSearchFocusIfNeeded()
                 }
 
                 if vm.isLoading {
@@ -133,6 +132,11 @@ struct SearchView: View {
             } message: {
                 Text(vm.errorMessage ?? "")
             }
+            .onChange(of: nav.pendingArtist) { _, artist in
+                guard let artist else { return }
+                nav.pendingArtist = nil
+                navigationPath.append(artist)
+            }
             .enableInjection()
         }
     }
@@ -182,5 +186,16 @@ struct SearchView: View {
             }
             .listStyle(.plain)
         }
+    }
+
+    private func applyPendingSearchFocusIfNeeded() {
+        guard nav.selectedTab == .search else { return }
+        guard nav.searchBarFocusRequestID > lastHandledSearchFocusRequestID else { return }
+        lastHandledSearchFocusRequestID = nav.searchBarFocusRequestID
+        // ネスト画面（アーティスト詳細等）にいる場合はルートに戻す
+        if !navigationPath.isEmpty {
+            navigationPath = NavigationPath()
+        }
+        isSearchBarFocused = true
     }
 }

--- a/Night-Core-Player/Features/Search/SearchViewModel.swift
+++ b/Night-Core-Player/Features/Search/SearchViewModel.swift
@@ -128,9 +128,12 @@ final class SearchViewModel {
 
     func resetToHistory() {
         searchTask?.cancel()
+        searchTask = nil
         query = ""
         songs = []
         artists = []
+        isLoading = false
+        isLoadingMore = false
         hasMoreSongs = false
         currentOffset = 0
         lastSearchedQuery = ""

--- a/Night-Core-Player/Features/Search/SearchViewModel.swift
+++ b/Night-Core-Player/Features/Search/SearchViewModel.swift
@@ -126,6 +126,17 @@ final class SearchViewModel {
         query = keyword
     }
 
+    func resetToHistory() {
+        searchTask?.cancel()
+        query = ""
+        songs = []
+        artists = []
+        hasMoreSongs = false
+        currentOffset = 0
+        lastSearchedQuery = ""
+        errorMessage = nil
+    }
+
     func removeHistoryItem(at index: Int) {
         guard searchHistory.indices.contains(index) else { return }
         searchHistory.remove(at: index)

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -60,7 +60,20 @@ struct SettingsView: View {
                                     .padding(.vertical, 12)
                                 }
                             } else if name == "ご意見・お問い合わせ" {
-                                Link(destination: contactMailURL) {
+                                Link(destination: contactFormURL) {
+                                    HStack {
+                                        Text(name)
+                                            .font(.body)
+                                            .foregroundColor(.primary)
+                                        Spacer()
+                                        Image(systemName: "chevron.right")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    .padding(.vertical, 12)
+                                }
+                            } else if name == "利用規約・プライバシーポリシー" {
+                                Link(destination: termsURL) {
                                     HStack {
                                         Text(name)
                                             .font(.body)
@@ -105,8 +118,6 @@ struct SettingsView: View {
                     SettingsPlaybackSpeedView(settingsVM: settingsVM)
                         .navigationTitle("サウンド設定")
                         .navigationBarTitleDisplayMode(.inline)
-                case "利用規約・プライバシーポリシー":
-                    TermsView()
                 default:
                     Text(name)
                         .font(.title2)
@@ -119,9 +130,11 @@ struct SettingsView: View {
         .enableInjection()
     }
 
-    private var contactMailURL: URL {
-        let subject = "NightCore Player お問い合わせ"
-        let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        return URL(string: "mailto:rmizutani.work@example.com?subject=\(encodedSubject)")!
+    private var contactFormURL: URL {
+        URL(string: "https://forms.gle/p5CTaqH4omaJiEFx6")!
+    }
+
+    private var termsURL: URL {
+        URL(string: "https://mizuryu.github.io/NightCorePlayer/terms/")!
     }
 }

--- a/Night-Core-Player/Services/MPMusicPlayerAdapter.swift
+++ b/Night-Core-Player/Services/MPMusicPlayerAdapter.swift
@@ -37,6 +37,17 @@ final class MPMusicPlayerAdapter: PlayerControllable {
     func seek(to time: TimeInterval) { player.currentPlaybackTime = time }
     func skipToNext() { player.skipToNextItem() }
     func skipToPrevious() { player.skipToPreviousItem() }
+    func prepareToPlay() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            player.prepareToPlay { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
     func setQueue(with descriptor: MPMusicPlayerPlayParametersQueueDescriptor) { player.setQueue(with: descriptor) }
     func prepend(_ descriptor: MPMusicPlayerPlayParametersQueueDescriptor) { player.prepend(descriptor) }
     func stop() { player.stop() }

--- a/Night-Core-Player/Services/MusicKitService.swift
+++ b/Night-Core-Player/Services/MusicKitService.swift
@@ -21,6 +21,23 @@ extension MusicKitService {
     }
 }
 
+enum PlaylistSongsFetchError: LocalizedError {
+    case tracksUnavailable(name: String, playlistID: String, kind: String?, reason: String?)
+    case emptyPlaylist(name: String, playlistID: String, kind: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case let .tracksUnavailable(name, _, _, reason):
+            if let reason, !reason.isEmpty {
+                return "プレイリスト「\(name)」の曲を取得できませんでした: \(reason)"
+            }
+            return "プレイリスト「\(name)」の曲を取得できませんでした"
+        case let .emptyPlaylist(name, _, _):
+            return "プレイリスト「\(name)」には表示できる曲がありません"
+        }
+    }
+}
+
 // MARK: - MusicKitClient
 
 protocol MusicKitClient: Sendable {
@@ -84,13 +101,83 @@ struct DefaultMusicKitClient: MusicKitClient {
         return Array(res.items.prefix(limit))
     }
     func fetchSongs(in playlist: Playlist) async throws -> [Song] {
-        let detailed: Playlist = try await playlist.with([.tracks])
-        return detailed.tracks?
-            .compactMap { track in
-                if case let .song(song) = track { return song }
-                else { return nil}
+        let playlistID = playlist.id.rawValue
+        let playlistKind = playlist.kind.map { String(describing: $0) }
+        var lastErrorDescription: String?
+
+        do {
+            let detailed: Playlist = try await playlist.with([.tracks])
+            let songs = extractSongs(from: detailed.tracks)
+            if !songs.isEmpty {
+                return songs
             }
-        ?? []
+        } catch {
+            lastErrorDescription = error.localizedDescription
+            print("⚠️ playlist.with([.tracks]) failed: \(error.localizedDescription)")
+        }
+
+        var req = MusicLibraryRequest<Playlist>()
+        req.filter(matching: \.id, equalTo: playlist.id)
+        let res = try await req.response()
+        guard let libraryPlaylist = res.items.first else {
+            throw PlaylistSongsFetchError.tracksUnavailable(
+                name: playlist.name,
+                playlistID: playlistID,
+                kind: playlistKind,
+                reason: lastErrorDescription
+            )
+        }
+
+        do {
+            let detailed = try await libraryPlaylist.with([.tracks])
+            let songs = extractSongs(from: detailed.tracks)
+            if !songs.isEmpty {
+                return songs
+            }
+        } catch {
+            lastErrorDescription = error.localizedDescription
+            print("⚠️ libraryPlaylist.with([.tracks]) failed: \(error.localizedDescription)")
+        }
+
+        do {
+            let detailed = try await libraryPlaylist.with([.entries])
+            let songs = extractSongs(from: detailed.entries)
+            if !songs.isEmpty {
+                return songs
+            }
+            throw PlaylistSongsFetchError.emptyPlaylist(
+                name: playlist.name,
+                playlistID: playlistID,
+                kind: playlistKind
+            )
+        } catch let error as PlaylistSongsFetchError {
+            throw error
+        } catch {
+            lastErrorDescription = error.localizedDescription
+            print("⚠️ libraryPlaylist.with([.entries]) failed: \(error.localizedDescription)")
+        }
+
+        throw PlaylistSongsFetchError.tracksUnavailable(
+            name: playlist.name,
+            playlistID: playlistID,
+            kind: playlistKind,
+            reason: lastErrorDescription
+        )
+    }
+
+    private func extractSongs(from tracks: MusicItemCollection<Track>?) -> [Song] {
+        tracks?.compactMap { track -> Song? in
+            if case let .song(song) = track { return song }
+            return nil
+        } ?? []
+    }
+
+    @available(iOS 16.0, *)
+    private func extractSongs(from entries: MusicItemCollection<Playlist.Entry>?) -> [Song] {
+        entries?.compactMap { entry -> Song? in
+            if case let .song(song)? = entry.item { return song }
+            return nil
+        } ?? []
     }
 }
 
@@ -141,7 +228,9 @@ final class MusicKitServiceImpl: MusicKitService {
     }
     func fetchPlaylistSongs(in playlist: Playlist) async throws -> [Song] {
         try await ensureAuth()
-        return try await client.fetchSongs(in: playlist)
+        let songs = try await client.fetchSongs(in: playlist)
+        print("🎵 fetchPlaylistSongs: \(songs.count) songs loaded for '\(playlist.name)' [id=\(playlist.id.rawValue)]")
+        return songs
     }
 
     func fetchPersonalRecommendations(limit: Int = Constants.Recommendation.defaultLimit) async throws -> [Song] {

--- a/Night-Core-Player/Services/MusicKitService.swift
+++ b/Night-Core-Player/Services/MusicKitService.swift
@@ -89,7 +89,6 @@ struct DefaultMusicKitClient: MusicKitClient {
         req.limit = limit
         req.offset = offset
         let res = try await req.response()
-        // アーティストIDに一致する楽曲のみフィルタリング
         return res.songs.filter { song in
             song.artistURL == artist.url || song.artistName == artist.name
         }
@@ -113,7 +112,9 @@ struct DefaultMusicKitClient: MusicKitClient {
             }
         } catch {
             lastErrorDescription = error.localizedDescription
+            #if DEBUG
             print("⚠️ playlist.with([.tracks]) failed: \(error.localizedDescription)")
+            #endif
         }
 
         var req = MusicLibraryRequest<Playlist>()
@@ -136,7 +137,9 @@ struct DefaultMusicKitClient: MusicKitClient {
             }
         } catch {
             lastErrorDescription = error.localizedDescription
+            #if DEBUG
             print("⚠️ libraryPlaylist.with([.tracks]) failed: \(error.localizedDescription)")
+            #endif
         }
 
         do {
@@ -154,7 +157,9 @@ struct DefaultMusicKitClient: MusicKitClient {
             throw error
         } catch {
             lastErrorDescription = error.localizedDescription
+            #if DEBUG
             print("⚠️ libraryPlaylist.with([.entries]) failed: \(error.localizedDescription)")
+            #endif
         }
 
         throw PlaylistSongsFetchError.tracksUnavailable(
@@ -229,7 +234,9 @@ final class MusicKitServiceImpl: MusicKitService {
     func fetchPlaylistSongs(in playlist: Playlist) async throws -> [Song] {
         try await ensureAuth()
         let songs = try await client.fetchSongs(in: playlist)
+        #if DEBUG
         print("🎵 fetchPlaylistSongs: \(songs.count) songs loaded for '\(playlist.name)' [id=\(playlist.id.rawValue)]")
+        #endif
         return songs
     }
 

--- a/Night-Core-Player/Services/MusicKitService.swift
+++ b/Night-Core-Player/Services/MusicKitService.swift
@@ -9,6 +9,7 @@ protocol MusicKitService: Sendable {
     func searchSongs(keyword: String, limit: Int, offset: Int) async throws -> [Song]
     func searchArtists(keyword: String, limit: Int) async throws -> [Artist]
     func fetchArtistTopSongs(artist: Artist) async throws -> [Song]
+    func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song]
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist]
     func fetchPlaylistSongs(in playlist: Playlist) async throws -> [Song]
     func fetchPersonalRecommendations(limit: Int) async throws -> [Song]
@@ -27,6 +28,7 @@ protocol MusicKitClient: Sendable {
     func searchCatalogSongs(term: String, limit: Int, offset: Int) async throws -> [Song]
     func searchCatalogArtists(term: String, limit: Int) async throws -> [Artist]
     func fetchArtistTopSongs(artist: Artist) async throws -> [Song]
+    func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song]
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist]
     func fetchSongs(in playlist: Playlist) async throws -> [Song]
 }
@@ -64,6 +66,16 @@ struct DefaultMusicKitClient: MusicKitClient {
         req.limit = 25
         let res = try await req.response()
         return Array(res.songs)
+    }
+    func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song] {
+        var req = MusicCatalogSearchRequest(term: artist.name, types: [Song.self])
+        req.limit = limit
+        req.offset = offset
+        let res = try await req.response()
+        // アーティストIDに一致する楽曲のみフィルタリング
+        return res.songs.filter { song in
+            song.artistURL == artist.url || song.artistName == artist.name
+        }
     }
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist] {
         var req = MusicLibraryRequest<Playlist>()
@@ -118,6 +130,10 @@ final class MusicKitServiceImpl: MusicKitService {
     func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
         try await ensureAuth()
         return try await client.fetchArtistTopSongs(artist: artist)
+    }
+    func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song] {
+        try await ensureAuth()
+        return try await client.fetchArtistSongs(artist: artist, limit: limit, offset: offset)
     }
     func fetchLibraryPlaylists(limit: Int = 10) async throws -> [Playlist] {
         try await ensureAuth()

--- a/Night-Core-Player/Services/MusicPlayerService.swift
+++ b/Night-Core-Player/Services/MusicPlayerService.swift
@@ -23,6 +23,7 @@ public protocol PlayerControllable: Sendable {
     func seek(to time: TimeInterval)
     func skipToNext()
     func skipToPrevious()
+    func prepareToPlay() async throws
     func setQueue(with descriptor: MPMusicPlayerPlayParametersQueueDescriptor)
     func prepend(_ descriptor: MPMusicPlayerPlayParametersQueueDescriptor)
     func stop()
@@ -107,4 +108,6 @@ protocol MusicPlayerService: Sendable {
     var nowPlayingIndex: Int { get }
     var playHistory: [Song] { get }
     func clearHistory() throws
+
+    var playbackErrorPublisher: AnyPublisher<Error, Never> { get }
 }

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -480,18 +480,24 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             return
         }
 
-        // 非ローテーション descriptor では player index の delta が
-        // そのまま queue.currentIndex の delta に対応する。
+        // nowPlayingItem の ID で内部キューを照合（シャッフル時も正確）
+        if let nowPlaying = player.nowPlayingItem,
+           let persistentID = nowPlaying.value(forProperty: MPMediaItemPropertyPersistentID) as? UInt64 {
+            let idString = String(persistentID)
+            if let matchIndex = queue.items.firstIndex(where: { $0.id.rawValue == idString }) {
+                queue.currentIndex = matchIndex
+                updateSnapshot()
+                return
+            }
+        }
+
+        // ID 照合できない場合は delta ベースのフォールバック
         let delta = playerIndex - previousPlayerIndex
         let newIndex = queue.currentIndex + delta
 
         if newIndex >= 0 && newIndex < queue.items.count {
             queue.currentIndex = newIndex
         } else if newIndex < 0 {
-            // repeat all でラップアラウンド: descriptor 先頭に戻る
-            // descriptor は queue.items[descriptorStart...] なので先頭は不明だが、
-            // playerIndex=0 は「descriptor 構築時の currentIndex」に対応。
-            // 現時点の currentIndex - previousPlayerIndex でベースを推定。
             let baseIndex = queue.currentIndex - previousPlayerIndex
             let wrapped = max(baseIndex + playerIndex, 0)
             queue.currentIndex = min(wrapped, queue.items.count - 1)

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -602,16 +602,20 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             do {
                 try await player.prepareToPlay()
             } catch {
+                #if DEBUG
                 print("⚠️ prepareToPlay failed: \(error.localizedDescription)")
+                #endif
                 playbackErrorSubject.send(error)
                 return
             }
+            if preserveCurrentTime {
+                player.seek(to: currentPos)
+            }
             player.play()
-        }
-        applyRepeatModeToPlayer()
-        if preserveCurrentTime {
+        } else if preserveCurrentTime {
             player.seek(to: currentPos)
         }
+        applyRepeatModeToPlayer()
         player.playbackRate = currentPlaybackRate
     }
 

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -225,11 +225,10 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
 
     public func moveItem(from src: Int, to dst: Int) async {
         let action = await queue.moveItem(from: src, to: dst)
-        if action == .updatePlayerQueueOnly, player.playbackState == .playing {
-            await handleQueueAction(action)
-            return
+        if action == .updatePlayerQueueOnly {
+            // 再生中はキュー再構築を遅延して音途切れを防ぐ
+            pendingShuffleResync = true
         }
-        needsQueueRefresh = action == .updatePlayerQueueOnly
         updateSnapshot()
     }
 

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -13,9 +13,14 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
 
     private var originalQueue: [Song] = []
     private var lastSnapshotSongID: String? = nil
+    private let playbackErrorSubject = PassthroughSubject<Error, Never>()
 
     public var snapshotPublisher: AnyPublisher<MusicPlayerSnapshot, Never> {
         $snapshot.eraseToAnyPublisher()
+    }
+
+    public var playbackErrorPublisher: AnyPublisher<Error, Never> {
+        playbackErrorSubject.eraseToAnyPublisher()
     }
 
     public var musicPlayerQueue: [Song] { queue.items }
@@ -36,6 +41,8 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
 
     private var timerCancellable: AnyCancellable?
     private var lastPlayerIndex: Int? = nil
+    private var pendingNativeNowPlayingIndex: Int? = nil
+    private var pendingShuffleResync: Bool = false
     private var needsQueueRefresh: Bool = false
     private var isFetchingRecommendations: Bool = false
     private var hasStarted: Bool = false
@@ -112,9 +119,18 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     @objc private func handlePlaybackStateChange(_ notification: Notification) {
         if player.playbackState == .playing {
             player.playbackRate = currentPlaybackRate
+            return
         }
-        // キュー末尾で停止した場合のみ自動再生をチェック（一時停止では発火しない）
+
         if player.playbackState == .stopped {
+            if repeatMode == .one, queue.currentSong != nil {
+                player.seek(to: 0)
+                player.play()
+                player.playbackRate = currentPlaybackRate
+                updateSnapshot()
+                return
+            }
+            // キュー末尾で停止した場合のみ自動再生をチェック（一時停止では発火しない）
             checkAutoPlayOnQueueEnd()
         }
     }
@@ -145,27 +161,51 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     }
 
     public func next() async {
-        let advanced = await queue.advanceToNextTrack()
-        if advanced {
+        if repeatMode == .one {
+            let advanced = await queue.advanceToNextTrack()
+            guard advanced else { return }
             await handleQueueAction(.playNewQueue)
             return
         }
-        // キュー末尾到達: repeat all なら先頭へラップ
+
+        if queue.currentIndex + 1 < queue.items.count {
+            if pendingShuffleResync {
+                queue.currentIndex += 1
+                await handleQueueAction(.playNewQueue)
+                return
+            }
+            pendingNativeNowPlayingIndex = queue.currentIndex + 1
+            player.skipToNext()
+            return
+        }
+
         if repeatMode == .all && !queue.isEmpty {
             queue.currentIndex = 0
             await handleQueueAction(.playNewQueue)
             return
         }
-        // キュー末尾で自動再生が有効なら推薦楽曲を取得して再生
+
         if isAutoPlayEnabled && repeatMode == .none {
             await fetchAndPlayRecommendations()
         }
     }
 
     public func previous() async {
-        let regressed = await queue.regressToPreviousTrack()
-        guard regressed else { return }
-        await handleQueueAction(.playNewQueue)
+        if repeatMode == .one {
+            let regressed = await queue.regressToPreviousTrack()
+            guard regressed else { return }
+            await handleQueueAction(.playNewQueue)
+            return
+        }
+
+        guard queue.currentIndex > 0 else { return }
+        if pendingShuffleResync {
+            queue.currentIndex -= 1
+            await handleQueueAction(.playNewQueue)
+            return
+        }
+        pendingNativeNowPlayingIndex = queue.currentIndex - 1
+        player.skipToPrevious()
     }
 
     public func seek(to time: TimeInterval) async {
@@ -184,8 +224,12 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     // MARK: - Queue Operations
 
     public func moveItem(from src: Int, to dst: Int) async {
-        let _ = await queue.moveItem(from: src, to: dst)
-        needsQueueRefresh = true
+        let action = await queue.moveItem(from: src, to: dst)
+        if action == .updatePlayerQueueOnly, player.playbackState == .playing {
+            await handleQueueAction(action)
+            return
+        }
+        needsQueueRefresh = action == .updatePlayerQueueOnly
         updateSnapshot()
     }
 
@@ -242,11 +286,12 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     // MARK: - Shuffle / Repeat
 
     public func toggleShuffle() async {
+        let shouldResumePlayback = player.playbackState == .playing
         if isShuffled {
-            // シャッフル OFF: 元の順序に復元
             guard !originalQueue.isEmpty else {
                 isShuffled = false
                 player.shuffleMode = .off
+                saveState()
                 updateSnapshot()
                 return
             }
@@ -257,23 +302,20 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             if let song = currentSong,
                let idx = restoredItems.firstIndex(where: { $0.id == song.id }) {
                 let _ = await queue.setQueue(restoredItems, startAt: idx)
-                await handleQueueAction(.updatePlayerQueueOnly)
             } else {
                 let _ = await queue.setQueue(restoredItems, startAt: 0)
-                await handleQueueAction(.playNewQueue)
             }
             isShuffled = false
         } else {
-            // シャッフル ON: 現在のキューを保存してシャッフル
             guard !queue.items.isEmpty else {
                 isShuffled = true
+                saveState()
                 updateSnapshot()
                 return
             }
             originalQueue = queue.items
             let currentSong = queue.currentSong
             var remaining = queue.items
-            // 現在の曲を除外してシャッフルし、先頭に再配置
             if let song = currentSong,
                let idx = remaining.firstIndex(where: { $0.id == song.id }) {
                 remaining.remove(at: idx)
@@ -283,15 +325,21 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
                 remaining.shuffle()
             }
             let _ = await queue.setQueue(remaining, startAt: 0)
-            await handleQueueAction(.updatePlayerQueueOnly)
             isShuffled = true
         }
         player.shuffleMode = .off
+        if shouldResumePlayback {
+            pendingShuffleResync = true
+            saveState()
+            updateSnapshot()
+            return
+        }
+        await syncPlayerQueue(autoPlay: shouldResumePlayback, preserveCurrentTime: true)
+        saveState()
         updateSnapshot()
     }
 
     public func cycleRepeatMode() async {
-        // player.repeatMode は .default を返す場合があるため、自前の repeatMode で状態管理
         let next: Constants.RepeatMode
         switch repeatMode {
         case .none: next = .all
@@ -299,11 +347,9 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         case .one:  next = .none
         }
         repeatMode = next
-        switch next {
-        case .none: player.repeatMode = .none
-        case .all:  player.repeatMode = .all
-        case .one:  player.repeatMode = .one
-        }
+
+        applyRepeatModeToPlayer()
+        saveState()
         updateSnapshot()
     }
 
@@ -359,29 +405,13 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     private func handleQueueAction(_ action: QueueUpdateAction, autoPlay: Bool = true) async {
         switch action {
         case .playNewQueue:
-            lastPlayerIndex = nil
-            if let descriptor = try? buildQueueDescriptor(from: await queue.items, startAt: queue.currentIndex) {
-                player.setQueue(with: descriptor)
-                if autoPlay {
-                    player.play()
-                }
-                player.playbackRate = currentPlaybackRate
-            } else {
-                player.stop()
-            }
+            await syncPlayerQueue(autoPlay: autoPlay, preserveCurrentTime: false)
             updateSnapshot()
         case .updatePlayerQueueOnly:
-            lastPlayerIndex = nil
-            if let descriptor = try? buildQueueDescriptor(from: await queue.items, startAt: queue.currentIndex) {
-                let wasPlaying = player.playbackState == .playing
-                let currentPos = player.currentTime
-                player.setQueue(with: descriptor)
-                player.seek(to: currentPos)
-                if wasPlaying {
-                    player.play()
-                }
-                player.playbackRate = currentPlaybackRate
-            }
+            await syncPlayerQueue(
+                autoPlay: player.playbackState == .playing,
+                preserveCurrentTime: true
+            )
             updateSnapshot()
         case .playerShouldStop:
             player.stop()
@@ -451,8 +481,29 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         }
     }
 
+    private func applyRepeatModeToPlayer() {
+        switch repeatMode {
+        case .none:
+            player.repeatMode = .none
+        case .all:
+            player.repeatMode = .all
+        case .one:
+            player.repeatMode = .one
+        }
+    }
+
     private func trackChanged() {
         let playerIndex = player.indexOfNowPlayingItem
+
+        if let pendingIndex = pendingNativeNowPlayingIndex {
+            pendingNativeNowPlayingIndex = nil
+            lastPlayerIndex = playerIndex
+            if queue.items.indices.contains(pendingIndex) {
+                queue.currentIndex = pendingIndex
+            }
+            updateSnapshot()
+            return
+        }
 
         if needsQueueRefresh {
             needsQueueRefresh = false
@@ -521,9 +572,10 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         guard !songs.isEmpty, songs.indices.contains(index) else {
             throw NSError(domain: "MusicPlayerUtils", code: -2, userInfo: nil)
         }
-        // repeat all の場合は全曲ループが必要なのでローテーションして全曲含める
         let target: [Song]
-        if repeatMode == .all {
+        if repeatMode == .one {
+            target = [songs[index]]
+        } else if repeatMode == .all {
             target = Array(songs[index...]) + Array(songs[..<index])
         } else {
             target = Array(songs[index...])
@@ -535,6 +587,35 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         return MPMusicPlayerPlayParametersQueueDescriptor(playParametersQueue: params)
     }
 
+    private func syncPlayerQueue(autoPlay: Bool, preserveCurrentTime: Bool) async {
+        lastPlayerIndex = nil
+        pendingNativeNowPlayingIndex = nil
+        pendingShuffleResync = false
+
+        guard let descriptor = try? buildQueueDescriptor(from: queue.items, startAt: queue.currentIndex) else {
+            player.stop()
+            return
+        }
+
+        let currentPos = preserveCurrentTime ? player.currentTime : 0
+        player.setQueue(with: descriptor)
+        if autoPlay {
+            do {
+                try await player.prepareToPlay()
+            } catch {
+                print("⚠️ prepareToPlay failed: \(error.localizedDescription)")
+                playbackErrorSubject.send(error)
+                return
+            }
+            player.play()
+        }
+        applyRepeatModeToPlayer()
+        if preserveCurrentTime {
+            player.seek(to: currentPos)
+        }
+        player.playbackRate = currentPlaybackRate
+    }
+
     private func restore() async {
         let st: (queueIDs: [String], currentIndex: Int, playbackRate: Double, shuffleModeRaw: Int, repeatModeRaw: Int, isAutoPlayEnabled: Bool)
         do {
@@ -543,6 +624,15 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             st = ([], 0, Constants.MusicPlayer.defaultPlaybackRate,
                   MPMusicShuffleMode.off.rawValue, MPMusicRepeatMode.none.rawValue, false)
         }
+
+        let restoredRepeat = MPMusicRepeatMode(rawValue: st.repeatModeRaw) ?? .none
+        isShuffled = st.shuffleModeRaw != Int(MPMusicShuffleMode.off.rawValue)
+        switch restoredRepeat {
+        case .all:  repeatMode = .all
+        case .one:  repeatMode = .one
+        default:    repeatMode = .none
+        }
+        isAutoPlayEnabled = st.isAutoPlayEnabled
 
         do {
             let songs = try await persistenceService.fetchCatalogSongs(st.queueIDs)
@@ -567,15 +657,7 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         currentPlaybackRate = rateManager.defaultRate
         player.playbackRate = rateManager.defaultRate
         player.shuffleMode  = .off  // アプリ側シャッフルのため常にoff
-        let restoredRepeat = MPMusicRepeatMode(rawValue: st.repeatModeRaw) ?? .none
-        player.repeatMode   = restoredRepeat
-        isShuffled = st.shuffleModeRaw != Int(MPMusicShuffleMode.off.rawValue)
-        switch restoredRepeat {
-        case .all:  repeatMode = .all
-        case .one:  repeatMode = .one
-        default:    repeatMode = .none
-        }
-        isAutoPlayEnabled = st.isAutoPlayEnabled
+        applyRepeatModeToPlayer()
     }
 
     private func saveState() {

--- a/Night-Core-PlayerTests/Features/Playlist/PlaylistDetailViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Playlist/PlaylistDetailViewModelTests.swift
@@ -29,6 +29,7 @@ struct PlaylistDetailViewModelTests {
         #expect(vm.songs.isEmpty, "songsが空であること")
         #expect(vm.errorMessage == nil, "errorMessageがnilであること")
         #expect(vm.isLoading == false, "isLoadingがfalseであること")
+        #expect(vm.isEmpty == false, "isEmptyがfalseであること")
     }
 
     @Test("load: 成功時、songsに取得した曲が設定され、errorMessageがnilであること")
@@ -49,6 +50,7 @@ struct PlaylistDetailViewModelTests {
         #expect(viewModel.songs == expectedSongs, "取得した曲がsongsに設定されること")
         #expect(viewModel.errorMessage == nil, "errorMessageがnilであること")
         #expect(viewModel.isLoading == false, "isLoadingがfalseに戻っていること")
+        #expect(viewModel.isEmpty == false, "isEmptyはfalseのままであること")
     }
 
     @Test("load: 失敗時、songsが空でerrorMessageが設定されること")
@@ -66,6 +68,7 @@ struct PlaylistDetailViewModelTests {
         #expect(viewModel.songs.isEmpty, "songsが空配列であること")
         #expect(viewModel.errorMessage == "失敗しました", "errorMessageにエラーの説明が設定されること")
         #expect(viewModel.isLoading == false, "isLoadingがfalseに戻っていること")
+        #expect(viewModel.isEmpty == false, "失敗時はisEmptyにならないこと")
     }
 
     @Test("load: 同時起動時、isLoadingがtrueのときは二重呼び出しを防止すること")
@@ -84,11 +87,17 @@ struct PlaylistDetailViewModelTests {
         #expect(serviceMock.fetchPlaylistSongsCallCount == 1, "同時呼び出しでも一度しかfetchされないこと")
     }
 
-    @Test("load: 結果が空の場合、songsが空で errorMessage が nil であること")
-    func load_emptyResult_hasEmptySongs() async {
+    @Test("load: emptyPlaylist エラーの場合、empty state になること")
+    func load_emptyPlaylist_setsEmptyState() async {
         // Given
         let (viewModel, serviceMock) = PlaylistDetailViewModelTests.setUp()
-        serviceMock.fetchPlaylistSongsResult = .success([])
+        serviceMock.fetchPlaylistSongsResult = .failure(
+            PlaylistSongsFetchError.emptyPlaylist(
+                name: "testTitle",
+                playlistID: "test",
+                kind: nil
+            )
+        )
 
         // When
         await viewModel.load()
@@ -97,6 +106,6 @@ struct PlaylistDetailViewModelTests {
         #expect(viewModel.songs.isEmpty, "songsが空であること")
         #expect(viewModel.errorMessage == nil, "errorMessageがnilであること")
         #expect(viewModel.isLoading == false, "isLoadingがfalseであること")
+        #expect(viewModel.isEmpty == true, "isEmptyがtrueであること")
     }
 }
-

--- a/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
@@ -39,7 +39,7 @@ final class MusicKitClientMock: MusicKitClient, @unchecked Sendable {
     }
     func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song] {
         fetchArtistSongsCalls.append((limit: limit, offset: offset))
-        return Array(artistSongs.prefix(limit))
+        return Array(artistSongs.dropFirst(offset).prefix(limit))
     }
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist] {
         fetchPlaylistCalls.append(limit)

--- a/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
@@ -9,6 +9,7 @@ final class MusicKitClientMock: MusicKitClient, @unchecked Sendable {
     var searchResult: [Song] = []
     var artistSearchResult: [Artist] = []
     var artistTopSongs: [Song] = []
+    var artistSongs: [Song] = []
     var playlists: [Playlist] = []
     var playlistSongs: [Song] = []
 
@@ -16,6 +17,7 @@ final class MusicKitClientMock: MusicKitClient, @unchecked Sendable {
     private(set) var searchCalls: [(term: String, limit: Int)] = []
     private(set) var searchArtistCalls: [(term: String, limit: Int)] = []
     private(set) var fetchArtistTopSongsCalls = 0
+    private(set) var fetchArtistSongsCalls: [(limit: Int, offset: Int)] = []
     private(set) var fetchPlaylistCalls: [Int] = []
     private(set) var fetchSongsCalls: [Playlist] = []
     
@@ -34,6 +36,10 @@ final class MusicKitClientMock: MusicKitClient, @unchecked Sendable {
     func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
         fetchArtistTopSongsCalls += 1
         return artistTopSongs
+    }
+    func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song] {
+        fetchArtistSongsCalls.append((limit: limit, offset: offset))
+        return Array(artistSongs.prefix(limit))
     }
     func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist] {
         fetchPlaylistCalls.append(limit)

--- a/Night-Core-PlayerTests/Mock/MusicKitServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicKitServiceMock.swift
@@ -17,6 +17,8 @@ final class MusicKitServiceMock: MusicKitService, @unchecked Sendable {
     var searchArtistsError: Error?
     var fetchArtistTopSongsCallCount = 0
     var fetchArtistTopSongsResult: Result<[Song], Error> = .success([])
+    var fetchArtistSongsCallArgs: [(limit: Int, offset: Int)] = []
+    var fetchArtistSongsResult: Result<[Song], Error> = .success([])
 
     // MARK: - Playlist トラッキング
     var fetchLibraryPlaylistsCallCount = 0
@@ -48,6 +50,14 @@ final class MusicKitServiceMock: MusicKitService, @unchecked Sendable {
     func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
         fetchArtistTopSongsCallCount += 1
         switch fetchArtistTopSongsResult {
+        case .success(let songs): return songs
+        case .failure(let error): throw error
+        }
+    }
+
+    func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song] {
+        fetchArtistSongsCallArgs.append((limit, offset))
+        switch fetchArtistSongsResult {
         case .success(let songs): return songs
         case .failure(let error): throw error
         }

--- a/Night-Core-PlayerTests/Mock/MusicPlayerServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicPlayerServiceMock.swift
@@ -24,20 +24,25 @@ final class PlayerControllableMock: PlayerControllable {
     private(set) var setQueueDescriptors: [MPMusicPlayerPlayParametersQueueDescriptor] = []
     private(set) var prependDescriptors: [MPMusicPlayerPlayParametersQueueDescriptor] = []
     private(set) var stopCount = 0
+    private(set) var prepareToPlayCount = 0
+    private(set) var actionLog: [String] = []
 
     func play() {
         playCount += 1
         playbackState = .playing
+        actionLog.append("play")
     }
 
     func pause() {
         pauseCount += 1
         playbackState = .paused
+        actionLog.append("pause")
     }
 
     func seek(to time: TimeInterval) {
         seekArgs.append(time)
         currentTime = time
+        actionLog.append("seek")
     }
 
     func skipToNext() {
@@ -50,17 +55,38 @@ final class PlayerControllableMock: PlayerControllable {
         indexOfNowPlayingItem = max(0, indexOfNowPlayingItem - 1)
     }
 
+    func prepareToPlay() async throws {
+        prepareToPlayCount += 1
+        actionLog.append("prepare")
+    }
+
     func setQueue(with descriptor: MPMusicPlayerPlayParametersQueueDescriptor) {
         setQueueDescriptors.append(descriptor)
+        actionLog.append("setQueue")
     }
 
     func prepend(_ descriptor: MPMusicPlayerPlayParametersQueueDescriptor) {
         prependDescriptors.append(descriptor)
+        actionLog.append("prepend")
     }
 
     func stop() {
         stopCount += 1
         playbackState = .stopped
+        actionLog.append("stop")
+    }
+
+    func resetRecording() {
+        playCount = 0
+        pauseCount = 0
+        seekArgs = []
+        skipNextCount = 0
+        skipPreviousCount = 0
+        setQueueDescriptors = []
+        prependDescriptors = []
+        stopCount = 0
+        prepareToPlayCount = 0
+        actionLog = []
     }
 }
 
@@ -176,6 +202,10 @@ final class MusicPlayerServiceMock: MusicPlayerService {
     public let snapshotSubject = PassthroughSubject<MusicPlayerSnapshot, Never>()
     public var snapshotPublisher: AnyPublisher<MusicPlayerSnapshot, Never> {
         snapshotSubject.eraseToAnyPublisher()
+    }
+    public let playbackErrorSubject = PassthroughSubject<Error, Never>()
+    public var playbackErrorPublisher: AnyPublisher<Error, Never> {
+        playbackErrorSubject.eraseToAnyPublisher()
     }
 
     // ViewModel が参照する状態

--- a/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
@@ -159,8 +159,8 @@ struct MusicQueueManagerTests {
         #expect(sut.adapter.seekArgs.count == beforeSeek)
     }
 
-    @Test("moveItem: 再生中に次曲以降を並び替えると即時に player queue へ反映される")
-    func testMoveItemWhilePlayingSyncsPlayerQueueImmediately() async {
+    @Test("moveItem: 再生中の並び替えは即時にプレイヤーキューを再構築せず遅延する")
+    func testMoveItemWhilePlayingDefersResync() async {
         // Given
         let sut = SUT.make()
         let A = makeDummySong(id: "A")
@@ -169,15 +169,14 @@ struct MusicQueueManagerTests {
         let D = makeDummySong(id: "D")
         await sut.service.setQueue(songs: [A, B, C, D], startAt: 0)
         sut.adapter.playbackState = .playing
-        sut.adapter.currentTime = 18
         sut.adapter.resetRecording()
         // When
         await sut.service.moveItem(from: 1, to: 3)
-        // Then
-        #expect(sut.adapter.actionLog.starts(with: ["setQueue", "prepare", "play", "seek"]))
-        #expect(sut.adapter.seekArgs.last == 18)
+        // Then: 内部キューは更新されるが、プレイヤーには即時反映しない（音途切れ防止）
+        #expect(sut.adapter.setQueueDescriptors.isEmpty, "moveItem 時点では setQueue しない")
+        #expect(sut.adapter.prepareToPlayCount == 0, "moveItem 時点では prepare しない")
         #expect(sut.service.nowPlayingIndex == 0, "現在曲の index は変わらない")
-        #expect(sut.service.musicPlayerQueue.map(\.id.rawValue) == ["A", "C", "D", "B"])
+        #expect(sut.service.musicPlayerQueue.map(\.id.rawValue) == ["A", "C", "D", "B"], "内部キューは更新済み")
     }
 
 
@@ -707,30 +706,21 @@ struct MusicPlayerServiceImplTests {
         #expect(sut.service.playHistory.count > historyBefore, "履歴が追加される")
     }
 
-    @Test("trackChanged: moveItem 後に trackChanged 発火で実際に setQueue/seek が呼ばれる")
-    func testMoveThenTrackChanged() async {
+    @Test("moveItem 後の next() でプレイヤーキューが再構築されること")
+    func testMoveThenNextResyncsQueue() async {
+        // Given
         let sut = SUT.make()
         let A = makeDummySong(id: "A")
         let B = makeDummySong(id: "B")
         let C = makeDummySong(id: "C")
-        // A(0) 再生中
-        await sut.service.setQueue(songs: [A,B,C], startAt: 0)
-        let beforeSet = sut.adapter.setQueueDescriptors.count
-        // C(2) → 1 に移動
+        await sut.service.setQueue(songs: [A, B, C], startAt: 0)
         await sut.service.moveItem(from: 2, to: 1)
-        // nowPlayingItem／indexOfNowPlayingItem を合わせておく
-        sut.adapter.indexOfNowPlayingItem = 0
-        // 曲変更通知をポスト
-        NotificationCenter.default.post(
-        name: .MPMusicPlayerControllerNowPlayingItemDidChange,
-        object: nil
-        )
-        // 少し待つか、async で待機
-        try? await Task.sleep(nanoseconds: 100_000_000)
-        // adapter.setQueue(with:) が１回増えている
-        #expect(sut.adapter.setQueueDescriptors.count == beforeSet + 1)
-        // seek(0) も呼ばれている
-        #expect(sut.adapter.seekArgs.last == 0)
+        sut.adapter.resetRecording()
+        // When
+        await sut.service.next()
+        // Then: 遅延再同期により setQueue + prepare + play が呼ばれる
+        #expect(sut.adapter.actionLog.starts(with: ["setQueue", "prepare", "play"]))
+        #expect(sut.service.nowPlayingIndex == 1)
     }
 
     @Test("toggleShuffle: アプリ側でキューがシャッフルされること")

--- a/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
@@ -144,19 +144,40 @@ struct MusicQueueManagerTests {
 
     @Test("moveItem: 非再生中の曲を移動すると即時再生操作は呼ばれず、フラグだけ立つ")
     func testMoveItemNonCurrent() async {
+        // Given
         let sut = SUT.make()
         let A = makeDummySong(id: "A")
         let B = makeDummySong(id: "B")
         let C = makeDummySong(id: "C")
-        // A(0) 再生中
         await sut.service.setQueue(songs: [A,B,C], startAt: 0)
         let beforeSet = sut.adapter.setQueueDescriptors.count
         let beforeSeek = sut.adapter.seekArgs.count
-        // C(2) を 1 に移動
+        // When
         await sut.service.moveItem(from: 2, to: 1)
-        // すぐには adapter.setQueue も seek も呼ばれない
+        // Then
         #expect(sut.adapter.setQueueDescriptors.count == beforeSet)
         #expect(sut.adapter.seekArgs.count == beforeSeek)
+    }
+
+    @Test("moveItem: 再生中に次曲以降を並び替えると即時に player queue へ反映される")
+    func testMoveItemWhilePlayingSyncsPlayerQueueImmediately() async {
+        // Given
+        let sut = SUT.make()
+        let A = makeDummySong(id: "A")
+        let B = makeDummySong(id: "B")
+        let C = makeDummySong(id: "C")
+        let D = makeDummySong(id: "D")
+        await sut.service.setQueue(songs: [A, B, C, D], startAt: 0)
+        sut.adapter.playbackState = .playing
+        sut.adapter.currentTime = 18
+        sut.adapter.resetRecording()
+        // When
+        await sut.service.moveItem(from: 1, to: 3)
+        // Then
+        #expect(sut.adapter.actionLog.starts(with: ["setQueue", "prepare", "play", "seek"]))
+        #expect(sut.adapter.seekArgs.last == 18)
+        #expect(sut.service.nowPlayingIndex == 0, "現在曲の index は変わらない")
+        #expect(sut.service.musicPlayerQueue.map(\.id.rawValue) == ["A", "C", "D", "B"])
     }
 
 
@@ -212,14 +233,12 @@ struct MusicQueueManagerTests {
             queueManager:  queueMock
         )
         
-        // 4) 前後のコール数をキャプチャ
+        // Given
         let beforeSet  = adapter.setQueueDescriptors.count
         let beforeStop = adapter.stopCount
-        
-        // — 実行 —
+        // When
         await service.removeItem(at: 5)   // 範囲外
-        
-        // — 検証 —
+        // Then
         #expect(adapter.setQueueDescriptors.count == beforeSet,
                 "範囲外なら setQueue(with:) が呼ばれない")
         #expect(adapter.stopCount == beforeStop,
@@ -519,30 +538,32 @@ struct MusicPlayerServiceImplTests {
         #expect(sut.service.snapshot.rate == Constants.MusicPlayer.maxPlaybackRate)
     }
 
-    @Test("next: .playNewQueueでadapter.setQueueが呼ばれること")
+    @Test("next: 通常ケースではadapter.skipToNextが呼ばれること")
     func testNextNormal() async {
-        // Given: 2曲セット済み、index=0
+        // Given
         let sut = SUT.make()
         let songs = [ makeDummySong(id: "A"), makeDummySong(id: "B") ]
         await sut.service.setQueue(songs: songs, startAt: 0)
-        let before = sut.adapter.setQueueDescriptors.count
-        // When: nextを呼ぶ
+        let beforeSetQueue = sut.adapter.setQueueDescriptors.count
+        // When
         await sut.service.next()
-        // Then: setQueueDescriptorsが1増える
-        #expect(sut.adapter.setQueueDescriptors.count == before + 1, "adapter.setQueue が呼ばれる")
+        // Then
+        #expect(sut.adapter.skipNextCount == 1, "adapter.skipToNext が呼ばれる")
+        #expect(sut.adapter.setQueueDescriptors.count == beforeSetQueue, "通常 next では setQueue を呼ばない")
     }
 
     @Test("next: 最後の曲で next() を呼んでも何もしないこと")
     func testNextAtEndNoOp() async {
-        // Given: 2曲セット、indexは末尾
+        // Given
         let sut = SUT.make()
         let songs = [ makeDummySong(id: "A"), makeDummySong(id: "B") ]
         await sut.service.setQueue(songs: songs, startAt: songs.count - 1)
         let before = sut.adapter.setQueueDescriptors.count
-        // When: nextを呼ぶ
+        // When
         await sut.service.next()
-        // Then: setQueueDescriptorsは変化しない
+        // Then
         #expect(sut.adapter.setQueueDescriptors.count == before, "末端では何もしない")
+        #expect(sut.adapter.skipNextCount == 0, "末端では skipToNext も呼ばれない")
     }
 
     @Test("previous: 最初の曲で previous() を呼んでも何もしないこと")
@@ -558,17 +579,18 @@ struct MusicPlayerServiceImplTests {
         #expect(sut.adapter.setQueueDescriptors.count == before, "先頭では何もしない")
     }
 
-    @Test("previous: .playNewQueueでadapter.setQueueが呼ばれること")
+    @Test("previous: 通常ケースではadapter.skipToPreviousが呼ばれること")
     func testPreviousNormal() async {
-        // Given: 2曲セット、index=1
+        // Given
         let sut = SUT.make()
         let songs = [ makeDummySong(id: "A"), makeDummySong(id: "B") ]
         await sut.service.setQueue(songs: songs, startAt: 1)
-        let before = sut.adapter.setQueueDescriptors.count
-        // When: previousを呼ぶ
+        let beforeSetQueue = sut.adapter.setQueueDescriptors.count
+        // When
         await sut.service.previous()
-        // Then: setQueueDescriptorsが1増える
-        #expect(sut.adapter.setQueueDescriptors.count == before + 1, "adapter.setQueue が呼ばれる")
+        // Then
+        #expect(sut.adapter.skipPreviousCount == 1, "adapter.skipToPrevious が呼ばれる")
+        #expect(sut.adapter.setQueueDescriptors.count == beforeSetQueue, "通常 previous では setQueue を呼ばない")
     }
 
     @Test("playNow: 指定した曲のみで即座に再生開始されること")
@@ -674,10 +696,14 @@ struct MusicPlayerServiceImplTests {
         let testSong2 = makeDummySong(id: "HIST_B")
         await sut.service.setQueue(songs: [testSong, testSong2], startAt: 0)
         let historyBefore = sut.service.playHistory.count
-        // When: next()で次の曲に進む（内部でsetQueue→updateSnapshot→履歴追加）
         sut.adapter.indexOfNowPlayingItem = 1
         await sut.service.next()
-        // Then: 履歴が増える（next()はplayNewQueueを呼び、updateSnapshotが新曲を検出）
+        NotificationCenter.default.post(
+            name: .MPMusicPlayerControllerNowPlayingItemDidChange,
+            object: nil
+        )
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
         #expect(sut.service.playHistory.count > historyBefore, "履歴が追加される")
     }
 
@@ -731,6 +757,64 @@ struct MusicPlayerServiceImplTests {
         #expect(sut.service.musicPlayerQueue.map(\.id.rawValue) == ["A","B","C"],
                 "元のキュー順が復元される")
     }
+
+    @Test("toggleShuffle: 再生中は即再キューせずキュー順だけ更新する")
+    func testToggleShuffleDefersQueueResyncWhilePlaying() async {
+        let sut = SUT.make()
+        let songs = [makeDummySong(id: "A"), makeDummySong(id: "B"), makeDummySong(id: "C")]
+        await sut.service.setQueue(songs: songs, startAt: 0)
+
+        sut.adapter.playbackState = .playing
+        sut.adapter.currentTime = 42
+        sut.adapter.resetRecording()
+
+        await sut.service.toggleShuffle()
+
+        #expect(sut.service.isShuffled)
+        #expect(sut.adapter.setQueueDescriptors.isEmpty, "toggle 時点では setQueue しない")
+        #expect(sut.adapter.prepareToPlayCount == 0, "toggle 時点では prepare しない")
+        #expect(sut.adapter.seekArgs.isEmpty, "toggle 時点では seek しない")
+        #expect(sut.service.musicPlayerQueue.first?.id.rawValue == "A")
+    }
+
+    @Test("toggleShuffle: 再生中に切り替えた後の next で初めて再同期する")
+    func testToggleShuffleResyncsOnNextWhilePlaying() async {
+        let sut = SUT.make()
+        let songs = [makeDummySong(id: "A"), makeDummySong(id: "B"), makeDummySong(id: "C")]
+        await sut.service.setQueue(songs: songs, startAt: 0)
+
+        sut.adapter.playbackState = .playing
+        await sut.service.toggleShuffle()
+        sut.adapter.resetRecording()
+
+        await sut.service.next()
+
+        #expect(sut.adapter.skipNextCount == 0, "pending resync 中は native skip しない")
+        #expect(sut.adapter.actionLog.starts(with: ["setQueue", "prepare", "play"]))
+    }
+
+    @Test("toggleShuffle: 再生中に切り替えた後の自然な trackChanged では再同期しない")
+    func testToggleShuffleDoesNotResyncOnNaturalTrackChange() async {
+        let sut = SUT.make()
+        let songs = [makeDummySong(id: "A"), makeDummySong(id: "B"), makeDummySong(id: "C")]
+        await sut.service.setQueue(songs: songs, startAt: 0)
+
+        sut.adapter.playbackState = .playing
+        sut.adapter.resetRecording()
+        await sut.service.toggleShuffle()
+        sut.adapter.resetRecording()
+
+        sut.adapter.indexOfNowPlayingItem = 1
+        NotificationCenter.default.post(
+            name: .MPMusicPlayerControllerNowPlayingItemDidChange,
+            object: nil
+        )
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(sut.adapter.setQueueDescriptors.isEmpty, "自然な曲送りでは setQueue しない")
+        #expect(sut.adapter.prepareToPlayCount == 0, "自然な曲送りでは prepare しない")
+        #expect(sut.adapter.playCount == 0, "自然な曲送りでは play を再度呼ばない")
+    }
     
     @Test("cycleRepeatMode: none→all→one→none の順に切り替わること")
     func testCycleRepeatMode() async {
@@ -750,6 +834,50 @@ struct MusicPlayerServiceImplTests {
         await sut.service.cycleRepeatMode()
         #expect(sut.adapter.repeatMode == .none, "adapter.repeatMode が .none に戻る")
         #expect(sut.service.repeatMode == .none, "service.repeatMode が .none に戻る")
+    }
+
+    @Test("repeat one: 再生中に設定したあと停止したら現在曲の先頭から再開する")
+    func testRepeatOneRestartsCurrentSongOnStop() async {
+        let sut = SUT.make()
+        await sut.service.setQueue(songs: [makeDummySong(id: "A")], startAt: 0)
+        await sut.service.cycleRepeatMode()
+        await sut.service.cycleRepeatMode()
+        #expect(sut.service.repeatMode == .one)
+
+        sut.adapter.resetRecording()
+        sut.adapter.playbackState = .stopped
+
+        NotificationCenter.default.post(
+            name: .MPMusicPlayerControllerPlaybackStateDidChange,
+            object: nil
+        )
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(sut.adapter.actionLog.starts(with: ["seek", "play"]))
+        #expect(sut.adapter.seekArgs.last == 0)
+        #expect(sut.adapter.playCount == 1)
+    }
+
+    @Test("cycleRepeatMode: 再生中は .one へ入っても即再キューしない")
+    func testCycleRepeatModeDefersResyncWhenEnteringOneWhilePlaying() async {
+        let sut = SUT.make()
+        await sut.service.setQueue(
+            songs: [makeDummySong(id: "A"), makeDummySong(id: "B")],
+            startAt: 0
+        )
+        sut.adapter.playbackState = .playing
+        sut.adapter.currentTime = 21
+        sut.adapter.resetRecording()
+
+        await sut.service.cycleRepeatMode()
+        sut.adapter.resetRecording()
+        await sut.service.cycleRepeatMode()
+
+        #expect(sut.service.repeatMode == .one)
+        #expect(sut.adapter.repeatMode == .one)
+        #expect(sut.adapter.setQueueDescriptors.isEmpty, "repeat toggle 時点では setQueue しない")
+        #expect(sut.adapter.prepareToPlayCount == 0, "repeat toggle 時点では prepare しない")
+        #expect(sut.adapter.seekArgs.isEmpty, "repeat toggle 時点では seek しない")
     }
 }
 

--- a/docs/adr/001-staged-queue-updates.md
+++ b/docs/adr/001-staged-queue-updates.md
@@ -1,0 +1,117 @@
+# ADR 001: 再生中のキュー更新は staged にし、曲切替境界で反映する
+
+> Status: Proposed
+> Date: 2026-03-29
+
+## Context
+
+NightCorePlayer では、再生中に次のようなキュー更新が発生する。
+
+- `shuffle` の ON / OFF
+- 再生キュー内の手動並び替え
+- 将来的な「次曲以降のみ変更」系の操作
+
+現在の `MPMusicPlayerController` ベース実装では、これらを即時に実プレイヤーへ反映するには `setQueue` が必要になる。
+しかし `setQueue -> prepareToPlay -> play/seek` は、実機上で一瞬の無音や停止を起こしやすい。
+
+今回の調査で次が分かった。
+
+- 即時反映を優先すると、再生中の音切れが起きやすい
+- 無音化のために再同期を遅延すると、自然な曲送りや `currentIndex` 同期を壊しやすい
+- 一方で、音楽アプリとして最優先すべきなのは「現在再生中の曲を切らない」ことである
+
+## Decision
+
+再生中のキュー更新は、即時に実プレイヤーへ反映しない。
+代わりに app 側で **staged queue** として保持し、次の境界で確定反映する。
+
+境界は次に固定する。
+
+- ユーザーが `next` / `previous` を押したとき
+- 自然な曲切替が起きた直後
+- `playNow` / `playNextAndPlay` / `setQueue` など、もともと明示的に queue 再構築が必要な操作時
+
+再生中の現在曲は維持し、staged queue は「次曲以降」にだけ効かせる。
+
+## Scope
+
+この ADR の対象は、再生中に upcoming queue を変更する操作のみ。
+
+対象:
+
+- `shuffle`
+- 手動 reorder
+- 将来の upcoming-only queue mutations
+
+対象外:
+
+- `repeat one` の現在曲ループ
+- `playNow` のように現在曲自体を切り替える操作
+- Apple Music backend 変更
+
+## Intended Behavior
+
+再生中に queue 更新が発生したときの仕様は次にする。
+
+1. UI 上のキュー順は即時に更新する
+2. 実プレイヤーの内部 queue はその場では更新しない
+3. 現在再生中の曲は切らない
+4. 次の境界で staged queue を実プレイヤーへ反映する
+
+このため、短時間だけ次のズレを許容する。
+
+- View 上の `次に再生`
+- 実際の player が保持する internal queue
+
+ただし、現在曲は常に一致していなければならない。
+
+## Consequences
+
+### Pros
+
+- `shuffle` や reorder 操作時の音切れを避けやすい
+- 現在再生中の曲を守れる
+- `shuffle` と手動 reorder を同じモデルで扱える
+
+### Cons
+
+- UI queue と実プレイヤー queue が一時的にズレる
+- `trackChanged` と `currentIndex` 同期の設計が重要になる
+- 「押した瞬間から厳密に upcoming が変わる」わけではない
+
+## Rejected Alternative
+
+### 1. 即時反映
+
+再生中の queue 更新ごとに `setQueue` する案。
+
+却下理由:
+
+- 実機で一瞬停止しやすい
+- ユーザー体験が悪い
+
+### 2. 完全な native queue 編集
+
+再生中の Apple Music queue を無停止で任意位置 move する案。
+
+却下理由:
+
+- 現在の `MPMusicPlayerController` 公開 API では現実的ではない
+- `setQueue` を避けて同等制御する手段がない
+
+## Implementation Notes
+
+実装時は次を守る。
+
+- `trackChanged()` は観測と同期に徹し、自然な曲進行を止めない
+- staged queue の適用は境界時だけに限定する
+- `repeat` は staged queue に混ぜず、ネイティブ repeat を優先する
+- reorder 中でも現在曲の index は壊さない
+
+## Acceptance Criteria
+
+- 再生中に `shuffle` を押しても、その瞬間に音が切れない
+- 再生中に upcoming queue を並び替えても、その瞬間に音が切れない
+- 自然な曲送りが止まらない
+- 境界到達後は UI queue と実プレイヤー queue が再び一致する
+


### PR DESCRIPTION
## Summary
- シャッフル時の再生途切れを修正（`prepareToPlay` 追加）
- 検索タブのタップ/長押し動作を修正（popToRoot 対応）
- プレイリスト曲取得のフォールバック強化（tracks → entries）
- Apple Music 未契約時のエラーメッセージ表示
- アーティスト名タップでアーティスト詳細画面へ遷移
- 再生キュー並び替え時の音途切れ防止（遅延再同期方式）
- Settings: 利用規約・お問い合わせの URL を正式リンクに更新
- 再生キューの操作パネル間隔を均等化
- テストコードに Given/When/Then コメントを追加

## Test plan
- [x] ビルド成功
- [x] 全テスト通過
- [ ] 実機でシャッフル時に音が途切れないこと
- [ ] 実機で検索タブ連続タップでルートに戻ること
- [ ] 実機でプレイリストの曲が表示されること
- [ ] 実機でアーティスト名タップで遷移すること
- [ ] 実機で再生キュー並び替え時に音が途切れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)