### PR TITLE
chore: lint/format/commitゲートの導入 (#70)

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,8 @@
+--swiftversion 5
+
+--indent 4
+--linebreaks lf
+
+--importgrouping testable-bottom
+
+--disable wrapArguments,wrapMultilineStatementBraces,wrapMultilineFunctionChains,wrapMultilineLiteralBrackets

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,93 @@
+# NightCorePlayer 用 SwiftLint 設定
+#
+# 既存コードスタイル（docs/specs/ARCHITECTURE.md）に合わせた現実的なしきい値。
+# - pre-commit（lefthook.yml）では変更ファイルのみ --strict で実行する
+#   → warning も error として扱われる。触ったファイルは警告ゼロが求められる
+# - Makefile の check ターゲットは --strict なしで全体を実行する
+#   → 既存コードの既存違反（print 等）で即座には落とさない
+#
+# 実測値に基づく緩和:
+#   - 最長行 ~143 文字                  → line_length warning 160
+#   - MusicPlayerServiceImpl.swift 691 行 → file_length warning 800
+#     （ARCHITECTURE.md が 300 行超の分割を「検討」扱いにしているため lint では強制しない）
+
+included:
+  - Night-Core-Player
+  - Night-Core-PlayerTests
+
+excluded:
+  - .build
+  - build
+
+disabled_rules:
+  # Protocol メソッド宣言での明示的な `-> Void` を許容する（MusicKitService 等）
+  - redundant_void_return
+
+opt_in_rules:
+  # 定番の低ノイズ系
+  - empty_count
+  - closure_spacing
+  - explicit_init
+  - closure_end_indentation
+  - first_where
+  - contains_over_first_not_nil
+  - sorted_first_last
+
+# ---- 既存コードから逸脱しないための緩和 ------------------------------------
+
+line_length:
+  warning: 160
+  error: 240
+
+file_length:
+  warning: 800
+  error: 1500
+
+type_body_length:
+  # legacy: MusicPlayerServiceImpl のクラス本体が 576 行
+  warning: 600
+  error: 1200
+
+function_body_length:
+  warning: 80
+  error: 200
+
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+
+identifier_name:
+  min_length: 1
+  excluded:
+    - id
+
+type_name:
+  min_length: 2
+  excluded:
+    - UI
+
+# LocalizationKeys / UIConstants の名前空間用ネストした enum を許容する
+nesting:
+  type_level:
+    warning: 2
+    error: 3
+
+# 永続化層のスナップショット型などで 3 要素以上のタプルを使っている
+large_tuple:
+  warning: 4
+  error: 6
+
+function_parameter_count:
+  warning: 7
+  error: 10
+
+# ---- プロジェクト固有ルール -------------------------------------------------
+
+custom_rules:
+  disallow_print:
+    name: "Disallow Print"
+    regex: '\bprint\b'
+    match_kinds:
+      - identifier
+    message: 'print() ではなく os.Logger を使用すること'
+    severity: warning

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+PROJECT := Night-Core-Player.xcodeproj
+SCHEME := Night-Core-Player
+
+# ローカル環境に合わせて上書き可: make test DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro'
+DESTINATION ?= platform=iOS Simulator,name=iPhone SE (3rd generation)
+
+.PHONY: check build lint swiftformat-lint test format
+
+check: build lint swiftformat-lint ## ビルド + Lint 一式
+
+build: ## デバッグビルドが通ることを確認
+	xcodebuild build \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-quiet
+
+lint: ## SwiftLint で全体を検査（警告は失敗にしない。--strict は pre-commit で実施）
+	swiftlint lint
+
+swiftformat-lint: ## SwiftFormat の整形漏れを検査（修正はしない）
+	swiftformat --lint .
+
+test: ## ユニットテスト実行
+	xcodebuild test \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-parallel-testing-enabled NO \
+		-quiet
+
+format: ## SwiftFormat で自動整形
+	swiftformat .

--- a/Night-Core-Player/Data/AppDataStore.swift
+++ b/Night-Core-Player/Data/AppDataStore.swift
@@ -4,7 +4,7 @@ import SwiftData
 struct AppDataStore {
     static let shared = AppDataStore()
     let container: ModelContainer
-    
+
     private init() {
         do {
             container = try ModelContainer(
@@ -37,4 +37,3 @@ struct AppDataStore {
         }
     }
 }
-

--- a/Night-Core-Player/Extensions/Song+CatalogIdentifier.swift
+++ b/Night-Core-Player/Extensions/Song+CatalogIdentifier.swift
@@ -6,7 +6,7 @@ extension Song {
         case encodingFailed
         case decodingFailed
     }
-    
+
     /// 永続化用の識別子を取得
     /// - playParameters が無ければ id.rawValue
     /// - JSON 化→辞書化して catalogId キー値を探す

--- a/Night-Core-Player/Features/Common/MiniMusicPlayerView.swift
+++ b/Night-Core-Player/Features/Common/MiniMusicPlayerView.swift
@@ -5,7 +5,7 @@ struct MiniMusicPlayerView: View {
     @ObserveInjection var inject
     @Environment(PlayerNavigator.self) private var nav
     @Environment(MusicPlayerViewModel.self) private var vm
-    
+
     var body: some View {
         VStack(spacing: 0) {
             GeometryReader { geo in
@@ -15,17 +15,17 @@ struct MiniMusicPlayerView: View {
                 Capsule()
                     .fill(Color.indigo)
                     .frame(width: geo.size.width * CGFloat(progress), height: 2)
-                    .offset(y:geo.size.height - 2)
+                    .offset(y: geo.size.height - 2)
             }
             .frame(height: 2)
-            
+
             HStack(spacing: 12) {
                 vm.artworkImage
                     .resizable()
                     .scaledToFit()
                     .frame(width: 40, height: 40)
                     .cornerRadius(4)
-                
+
                 MarqueeText(
                     text: vm.title,
                     font: .subheadline,
@@ -37,7 +37,7 @@ struct MiniMusicPlayerView: View {
                     selectedTab: nav.selectedTab
                 )
                 Spacer()
-                
+
                 Button(action: vm.previousTrack) {
                     Image(systemName: "backward.fill")
                         .font(.system(size: 20))

--- a/Night-Core-Player/Features/Common/PlayerNavigator.swift
+++ b/Night-Core-Player/Features/Common/PlayerNavigator.swift
@@ -13,6 +13,6 @@ final class PlayerNavigator {
     var initialIndex: Int = 0
 
     var searchBarFocusRequestID: Int = 0
-    var pendingArtist: Artist? = nil
+    var pendingArtist: Artist?
     var isScrolling: Bool = false
 }

--- a/Night-Core-Player/Features/Common/PlayingQueueItemRowView.swift
+++ b/Night-Core-Player/Features/Common/PlayingQueueItemRowView.swift
@@ -4,7 +4,7 @@ import MusicKit
 struct PlayingQueueItemRowView: View {
     let song: Song
     let isCurrent: Bool
-    
+
     var body: some View {
         HStack(spacing: 12) {
             if let url = song.artwork?.url(width: 44, height: 44) {
@@ -33,7 +33,7 @@ struct PlayingQueueItemRowView: View {
                     .background(Color(.secondarySystemBackground))
                     .cornerRadius(6)
             }
-            
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(song.title)
                     .font(.subheadline)
@@ -44,7 +44,7 @@ struct PlayingQueueItemRowView: View {
                     .foregroundColor(.secondary)
                     .lineLimit(1)
             }
-            
+
             Spacer()
         }
         .padding(.vertical, 4)

--- a/Night-Core-Player/Features/Common/SongRowView.swift
+++ b/Night-Core-Player/Features/Common/SongRowView.swift
@@ -5,7 +5,7 @@ import MusicKit
 struct SongRowView: View {
     @ObserveInjection var inject
     let song: Song
-    
+
     var body: some View {
         HStack {
             if song.artwork != nil {

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -6,7 +6,7 @@ struct SpeedControlButton: View {
     let label: String
     let color: Color
     let action: () -> Void
-    
+
     var body: some View {
         Button(action: action) {
             Text(label)
@@ -32,7 +32,7 @@ struct SliderTickMarksOverlay: View {
                 let value  = minValue + Double(i) * step
                 let ratio  = (value - minValue) / (maxValue - minValue)
                 let xPos   = geo.size.width * ratio
-                
+
                 VStack(spacing: 4) {
                     Text(String(format: "%.1f", value))
                         .font(.caption2)
@@ -53,12 +53,12 @@ struct MusicPlayerView: View {
     @Environment(MusicPlayerViewModel.self) private var vm
     @Environment(\.musicKitService) private var musicKitService
     @State private var isQueuePresented = false
-    
+
     init() {
         let clearImage = UIImage()
         UISlider.appearance().setThumbImage(clearImage, for: .normal)
     }
-    
+
     var body: some View {
         ZStack {
             VStack(spacing: 16) {
@@ -66,7 +66,7 @@ struct MusicPlayerView: View {
                     .font(.headline)
                     .padding(.top, 8)
                 Spacer()
-                
+
                 artworkView
                     .gesture(
                         DragGesture(minimumDistance: 50)
@@ -87,7 +87,7 @@ struct MusicPlayerView: View {
                             .font(.title2)
                             .foregroundColor(.indigo)
                     }
-                    
+
                     VStack {
                         let titleHeight = UIFont.preferredFont(forTextStyle: .title3).lineHeight
                         let subtitleHeight = UIFont.preferredFont(forTextStyle: .subheadline).lineHeight
@@ -145,7 +145,7 @@ struct MusicPlayerView: View {
                             .font(.title2)
                             .foregroundColor(.indigo)
                     }
-                    Button (action: {
+                    Button(action: {
                         vm.playPauseTrack()
                     }) {
                         Image(systemName: vm.isPlaying ? "pause.fill" : "play.fill")
@@ -159,9 +159,9 @@ struct MusicPlayerView: View {
                     }
                 }
                 .padding(.vertical, 8)
-                
+
                 Spacer(minLength: 20)
-                
+
                 VStack(spacing: 10) {
                     Slider(
                         value: Binding(
@@ -170,15 +170,14 @@ struct MusicPlayerView: View {
                         ),
                         in: Constants.MusicPlayer.minPlaybackRate...Constants.MusicPlayer.maxPlaybackRate,
                         step: 0.01
-                    ) { editing in
+                    ) { _ in
                     }
-                    
+
                     .frame(width: 340)
                     .accentColor(.indigo)
                     .overlay(SliderTickMarksOverlay())
                     .padding(.horizontal)
-                    
-                    
+
                     HStack(spacing: 12) {
                         SpeedControlButton(label: "-\(Constants.MusicPlayer.rateStepLarge)", color: .red) {
                             vm.adjustRate(by: -Constants.MusicPlayer.rateStepLarge)
@@ -199,7 +198,7 @@ struct MusicPlayerView: View {
                         }
                     }
                 }
-                
+
                 VStack(spacing: 4) {
                     Image(systemName: "list.bullet")
                         .font(.title2)

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerViewModel.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerViewModel.swift
@@ -10,10 +10,10 @@ final class MusicPlayerViewModel {
     private(set) var musicPlayerQueue: [Song] = []
     private(set) var currentIndex: Int = 0
     private(set) var history: [Song] = []
-    
+
     private(set) var title: String      = "—"
     private(set) var artist: String     = "—"
-    private(set) var artworkData: Data?  = nil
+    private(set) var artworkData: Data?
     private(set) var currentTime: Double = 0
 
     var artworkImage: Image {
@@ -35,7 +35,7 @@ final class MusicPlayerViewModel {
     var currentQueue: [Song] {
         Array(musicPlayerQueue.dropFirst(currentIndex + 1))
     }
-    
+
     var remainingTimeString: String {
         Self.formatRemainingTime(
             currentTime: currentTime,
@@ -44,16 +44,16 @@ final class MusicPlayerViewModel {
             rate: rate
             )
     }
-    
+
     // MARK: - Dependencies
     private let service: MusicPlayerService
     private var cancellables = Set<AnyCancellable>()
-    
+
     init(service: MusicPlayerService) {
         self.service = service
         bindService()
     }
-    
+
     func setQueue(_ songs: [Song], startAt idx: Int, autoPlay: Bool = true) {
         Task {
             await service.setQueue(songs: songs, startAt: idx, autoPlay: autoPlay)
@@ -111,23 +111,22 @@ final class MusicPlayerViewModel {
             errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
         }
     }
-    
+
     func toggleShuffle() {
         Task { await service.toggleShuffle() }
     }
-    
+
     func cycleRepeatMode() {
         Task { await service.cycleRepeatMode() }
     }
-    
+
     func toggleAutoPlay() {
         Task { await service.toggleAutoPlay() }
     }
-    
-    
-    func playPauseTrack()  { Task { await isPlaying ? service.pause() : service.play() } }
-    func nextTrack()       { Task { await service.next()     } }
-    func previousTrack()   { Task { await service.previous() } }
+
+    func playPauseTrack() { Task { await isPlaying ? service.pause() : service.play() } }
+    func nextTrack() { Task { await service.next()      } }
+    func previousTrack() { Task { await service.previous() } }
     func rewind15() {
         let newTime = max(currentTime - skipSeconds, 0)
         seek(to: newTime)
@@ -136,7 +135,7 @@ final class MusicPlayerViewModel {
         let newTime = min(currentTime + skipSeconds, duration)
         seek(to: newTime)
     }
-    func seek(to time: Double){
+    func seek(to time: Double) {
         currentTime = time
         Task {
             await service.seek(to: time)
@@ -152,13 +151,13 @@ final class MusicPlayerViewModel {
     func adjustRate(by delta: Double) {
         setRate(to: rate + delta)
     }
-    
+
     func loadPlaylist(songs: [Song], startAt index: Int = 0, autoPlay: Bool = true) {
         Task {
             await service.setQueue(songs: songs, startAt: index, autoPlay: autoPlay)
         }
     }
-    
+
     private var upcomingTracksDuration: Double {
         musicPlayerQueue
             .dropFirst(currentIndex + 1)
@@ -179,7 +178,7 @@ final class MusicPlayerViewModel {
         let s = Int(totalSec) % 60
         return String(format: "%02d:%02d", m, s)
     }
-    
+
     private func bindService() {
         service.snapshotPublisher
             .receive(on: DispatchQueue.main)

--- a/Night-Core-Player/Features/MusicPlayer/PlayingQueueView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/PlayingQueueView.swift
@@ -5,7 +5,7 @@ import MusicKit
 struct MusicPlayerControlsView: View {
     @ObserveInjection var inject
     @Environment(MusicPlayerViewModel.self) private var vm
-    
+
     var body: some View {
         VStack(spacing: 16) {
             VStack(spacing: 4) {
@@ -51,14 +51,14 @@ struct MusicPlayerControlsView: View {
             }
             .foregroundColor(.indigo)
             .padding(.vertical, 8)
-            
+
         }
     }
 }
 
 struct NowPlayingHeaderView: View {
     @Environment(MusicPlayerViewModel.self) private var vm
-    
+
     var body: some View {
         HStack {
             vm.artworkImage
@@ -79,7 +79,7 @@ struct NowPlayingHeaderView: View {
         }
         .padding(.horizontal)
         .padding(.bottom, 8)
-        
+
     }
 }
 
@@ -113,7 +113,7 @@ struct HistorySectionView: View {
                 }
                 Button("Cancel", role: .cancel) { }
             }
-                ForEach(Array(vm.history.enumerated()), id: \.offset) { idx, song in
+                ForEach(Array(vm.history.enumerated()), id: \.offset) { _, song in
                     PlayingQueueItemRowView(
                         song: song,
                         isCurrent: false
@@ -129,14 +129,14 @@ struct HistorySectionView: View {
 
 struct QueueSectionView: View {
     @Environment(MusicPlayerViewModel.self) private var vm
-    
+
     var body: some View {
         Text("Up Next")
             .font(.body).bold()
             .foregroundStyle(.primary)
             .padding(.vertical, 8)
             .id("queueHeader")
-                
+
         ForEach(Array(vm.currentQueue.enumerated()), id: \.element.id) { _, song in
             PlayingQueueItemRowView(
                 song: song,
@@ -149,7 +149,7 @@ struct QueueSectionView: View {
                     .padding(.trailing, 8)
             }
             .contentShape(Rectangle())
-            .onTapGesture{ vm.playNowNext(song) }
+            .onTapGesture { vm.playNowNext(song) }
             .listRowBackground(Color.clear)
         }
         .onMove(perform: vm.moveQueueItem)
@@ -159,13 +159,13 @@ struct QueueSectionView: View {
 
 struct CombinedListView: View {
     @Environment(MusicPlayerViewModel.self) private var vm
-    
+
     var body: some View {
         ScrollViewReader { proxy in
             List {
                 HistorySectionView()
                 QueueSectionView()
-                
+
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
@@ -185,19 +185,19 @@ struct CombinedListView: View {
         }
     }
 }
-    
+
 struct PlayingQueueView: View {
     @Environment(MusicPlayerViewModel.self) private var vm
-    
+
     var body: some View {
         VStack(spacing: 0) {
             Capsule()
                 .frame(width: 40, height: 5)
                 .foregroundColor(Color.secondary.opacity(0.6))
                 .padding(.vertical, 8)
-            
+
             NowPlayingHeaderView()
-            
+
             HStack {
                 Spacer()
                 Text("\(vm.currentQueue.count) items")
@@ -210,11 +210,11 @@ struct PlayingQueueView: View {
             .padding(.horizontal)
             .padding(.bottom, 8)
             .foregroundColor(.secondary)
-            
+
             CombinedListView()
-            
+
             Spacer()
-            
+
             HStack(spacing: 16) {
                 Spacer()
                 Button { vm.toggleShuffle() } label: {

--- a/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
@@ -20,8 +20,7 @@ struct PlaylistDetailView: View {
             if vm.isLoading {
                 ProgressView("Loading…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            else if vm.isEmpty {
+            } else if vm.isEmpty {
                 VStack(spacing: 12) {
                     Image(systemName: "music.note.list")
                         .font(.largeTitle)
@@ -30,8 +29,7 @@ struct PlaylistDetailView: View {
                         .multilineTextAlignment(.center)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            else if let msg = vm.errorMessage {
+            } else if let msg = vm.errorMessage {
                 VStack(spacing: 12) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.largeTitle)
@@ -43,8 +41,7 @@ struct PlaylistDetailView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            else {
+            } else {
                 VStack(spacing: 16) {
                     HStack(spacing: 16) {
                         playlistActionButton(

--- a/Night-Core-Player/Features/Playlist/PlaylistDetailViewModel.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistDetailViewModel.swift
@@ -10,20 +10,20 @@ final class PlaylistDetailViewModel {
     private(set) var isLoading = false
     private(set) var isEmpty = false
     private(set) var errorMessage: String?
-    
+
     private var musicKitService: MusicKitService
-    
+
     init(playlist: Playlist,
          musicKitService: MusicKitService) {
         self.playlist = playlist
         self.musicKitService = musicKitService
     }
-    
+
     func load() async {
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
-        
+
         do {
             songs = try await musicKitService.fetchPlaylistSongs(in: playlist)
             isEmpty = songs.isEmpty

--- a/Night-Core-Player/Features/Playlist/PlaylistView.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistView.swift
@@ -6,7 +6,7 @@ struct PlaylistView: View {
     @ObserveInjection var inject
     @Environment(PlaylistViewModel.self) private var vm
     @Environment(\.musicKitService) private var musicKitService
-    
+
     var body: some View {
         NavigationStack {
             content
@@ -19,25 +19,23 @@ struct PlaylistView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .enableInjection()
     }
-    
+
     @ViewBuilder
     private var content: some View {
         if vm.isLoading {
             loadingView
-        }
-        else if let msg = vm.errorMessage {
+        } else if let msg = vm.errorMessage {
             errorView(msg)
-        }
-        else {
+        } else {
             listView
         }
     }
-    
+
     private var loadingView: some View {
         ProgressView("Loading…")
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-    
+
     private func errorView(_ msg: String) -> some View {
         VStack(spacing: 12) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -51,7 +49,7 @@ struct PlaylistView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-    
+
     private var listView: some View {
         List {
             ForEach(vm.rows) { row in
@@ -85,5 +83,3 @@ struct PlaylistView: View {
         .background(Color(.systemBackground))
     }
 }
-
-

--- a/Night-Core-Player/Features/Playlist/PlaylistViewModel.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistViewModel.swift
@@ -6,24 +6,24 @@ import Observation
 @Observable
 @MainActor
 final class PlaylistViewModel {
-    
+
     var playlists: [Playlist] = []
     var rows: [PlaylistRowModel] = []
     var isLoading = false
     var errorMessage: String?
-    
+
     private var artworkCache: [MusicItemID: UIImage] = [:]
     private let musicKitService: MusicKitService
-    
+
     init(musicKitService: MusicKitService) {
         self.musicKitService = musicKitService
     }
-    
+
     func load(limit: Int = Constants.MusicAPI.playlistsLoadLimit) async {
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
-        
+
         do {
             let playlists = try await musicKitService.fetchLibraryPlaylists(limit: limit)
             self.rows = playlists.map { pl in
@@ -35,11 +35,12 @@ final class PlaylistViewModel {
                 )
             }
             errorMessage = nil
-            
+
             await withTaskGroup(of: Void.self) { group in
                 for pl in playlists {
                     group.addTask { [weak self] in
-                        await self?.fetchArtwork(for: pl)}
+                        await self?.fetchArtwork(for: pl)
+                    }
                 }
             }
         } catch {
@@ -47,16 +48,16 @@ final class PlaylistViewModel {
             playlists = []
         }
     }
-    
+
     // MARK: - Artwork 取得
     private func fetchArtwork(for playlist: Playlist) async {
         guard let url = playlist.artwork?.url(width: 100, height: 100) else { return }
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
             guard let uiImage = UIImage(data: data) else { return }
-            
+
             artworkCache[playlist.id] = uiImage
-            
+
             if let idx = rows.firstIndex(where: { $0.id == playlist.id }) {
                 rows[idx] = PlaylistRowModel(
                     id: rows[idx].id,
@@ -65,7 +66,7 @@ final class PlaylistViewModel {
                     playlist: rows[idx].playlist
                 )
             }
-            
+
         } catch {
         }
     }

--- a/Night-Core-Player/Features/Settings/SettingsPlaybackSpeedView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsPlaybackSpeedView.swift
@@ -11,7 +11,7 @@ struct SettingsPlaybackSpeedView: View {
         self.settingsVM = settingsVM
         _currentSpeed = State(initialValue: settingsVM.defaultRate)
     }
-    
+
     var body: some View {
         List {
             Text("Playback Speed")
@@ -20,16 +20,16 @@ struct SettingsPlaybackSpeedView: View {
                 .padding(.leading, 16)
                 .padding(.top, 8)
                 .listRowSeparator(.hidden)
-            
+
             HStack {
                 Text("×\(String(format: "%.2f", currentSpeed))")
                     .font(.body)
                     .fontWeight(.bold)
                     .foregroundColor(.secondary)
                     .frame(alignment: .leading)
-                
+
                 Spacer()
-                
+
                 Stepper(
                     value: $currentSpeed,
                     in: Constants.MusicPlayer.minPlaybackRate...Constants.MusicPlayer.maxPlaybackRate,
@@ -41,11 +41,11 @@ struct SettingsPlaybackSpeedView: View {
                     settingsVM.updateDefaultRate(to: newVal)
                 }
                 .labelsHidden()
-                
+
             }
             .listRowSeparator(.hidden)
             .padding(.horizontal, 16)
-            
+
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("On app launch, music will play at the configured playback speed.")
@@ -60,7 +60,7 @@ struct SettingsPlaybackSpeedView: View {
             .padding(.leading, 16)
             .padding(.vertical, 0)
             .listRowSeparator(.hidden)
-            
+
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -55,7 +55,7 @@ struct SettingsView: View {
                         .foregroundColor(.primary)
                         .padding(.top, 8)
                 }
-                
+
                 Section {
                     ForEach(OtherItem.allCases, id: \.self) { item in
                         VStack(spacing: 0) {

--- a/Night-Core-Player/Services/MusicKitService.swift
+++ b/Night-Core-Player/Services/MusicKitService.swift
@@ -5,7 +5,7 @@ import SwiftUI
 // MARK: - Protocol
 
 protocol MusicKitService: Sendable {
-    func ensureAuth() async throws -> Void
+    func ensureAuth() async throws
     func searchSongs(keyword: String, limit: Int, offset: Int) async throws -> [Song]
     func searchArtists(keyword: String, limit: Int) async throws -> [Artist]
     func fetchArtistTopSongs(artist: Artist) async throws -> [Song]
@@ -194,7 +194,7 @@ final class MusicKitServiceImpl: MusicKitService {
     init(client: MusicKitClient = DefaultMusicKitClient()) {
         self.client = client
     }
-    func ensureAuth() async throws -> Void {
+    func ensureAuth() async throws {
         let status = await client.requestAuthorization()
         guard status == .authorized else {
             throw NSError(

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -12,7 +12,7 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     @Published public private(set) var isAutoPlayEnabled: Bool = false
 
     private var originalQueue: [Song] = []
-    private var lastSnapshotSongID: String? = nil
+    private var lastSnapshotSongID: String?
     private let playbackErrorSubject = PassthroughSubject<Error, Never>()
 
     public var snapshotPublisher: AnyPublisher<MusicPlayerSnapshot, Never> {
@@ -40,8 +40,8 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     private let maxPlaybackRate: Double = Constants.MusicPlayer.maxPlaybackRate
 
     private var timerCancellable: AnyCancellable?
-    private var lastPlayerIndex: Int? = nil
-    private var pendingNativeNowPlayingIndex: Int? = nil
+    private var lastPlayerIndex: Int?
+    private var pendingNativeNowPlayingIndex: Int?
     private var pendingShuffleResync: Bool = false
     private var needsQueueRefresh: Bool = false
     private var isFetchingRecommendations: Bool = false
@@ -53,8 +53,8 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         historyManager: PlayHistoryManaging,
         artworkService: ArtworkCacheService,
         musicKitService: MusicKitService? = nil,
-        playerAdapter : PlayerControllable? = nil,
-        queueManager : QueueManaging? = nil
+        playerAdapter: PlayerControllable? = nil,
+        queueManager: QueueManaging? = nil
     ) {
         self.rateManager = rateManager
         self.persistenceService = persistenceService
@@ -300,9 +300,9 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
 
             if let song = currentSong,
                let idx = restoredItems.firstIndex(where: { $0.id == song.id }) {
-                let _ = await queue.setQueue(restoredItems, startAt: idx)
+                _ = await queue.setQueue(restoredItems, startAt: idx)
             } else {
-                let _ = await queue.setQueue(restoredItems, startAt: 0)
+                _ = await queue.setQueue(restoredItems, startAt: 0)
             }
             isShuffled = false
         } else {
@@ -323,7 +323,7 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             } else {
                 remaining.shuffle()
             }
-            let _ = await queue.setQueue(remaining, startAt: 0)
+            _ = await queue.setQueue(remaining, startAt: 0)
             isShuffled = true
         }
         player.shuffleMode = .off
@@ -444,13 +444,13 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         let existingArtwork = snapshot.artworkData
 
         snapshot = MusicPlayerSnapshot(
-            title:       title,
-            artist:      artist,
+            title: title,
+            artist: artist,
             artworkData: existingArtwork,
             currentTime: currentTime,
-            duration:    duration,
-            rate:        rate,
-            isPlaying:   isPlaying
+            duration: duration,
+            rate: rate,
+            isPlaying: isPlaying
         )
 
         guard isNewSong else { return }
@@ -468,13 +468,13 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             guard let self = self else { return }
             let fetchedData = await self.artworkService.getArtwork(for: song)
             let updated = MusicPlayerSnapshot(
-                title:       title,
-                artist:      artist,
+                title: title,
+                artist: artist,
                 artworkData: fetchedData,
                 currentTime: currentTime,
-                duration:    duration,
-                rate:        rate,
-                isPlaying:   isPlaying
+                duration: duration,
+                rate: rate,
+                isPlaying: isPlaying
             )
             self.snapshot = updated
         }
@@ -677,11 +677,11 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
 
         do {
             try persistenceService.saveQueueState(
-                queueIDs:      queue.items.map { $0.id.rawValue },
-                currentIndex:  queue.currentIndex,
-                playbackRate:  rateManager.defaultRate,
+                queueIDs: queue.items.map { $0.id.rawValue },
+                currentIndex: queue.currentIndex,
+                playbackRate: rateManager.defaultRate,
                 shuffleModeRaw: shuffleModeRaw,
-                repeatModeRaw:  repeatModeRaw,
+                repeatModeRaw: repeatModeRaw,
                 isAutoPlayEnabled: isAutoPlayEnabled
             )
         } catch {

--- a/Night-Core-Player/Services/MusicQueueManager.swift
+++ b/Night-Core-Player/Services/MusicQueueManager.swift
@@ -27,9 +27,7 @@ public final class MusicQueueManager: QueueManaging {
               items.indices.contains(dst) else { return .noAction }
         let song = items.remove(at: src)
         items.insert(song, at: dst)
-        if src == currentIndex { currentIndex = dst }
-        else if src < currentIndex && dst >= currentIndex { currentIndex -= 1 }
-        else if src > currentIndex && dst <= currentIndex { currentIndex += 1 }
+        if src == currentIndex { currentIndex = dst } else if src < currentIndex && dst >= currentIndex { currentIndex -= 1 } else if src > currentIndex && dst <= currentIndex { currentIndex += 1 }
         return .updatePlayerQueueOnly
     }
 

--- a/Night-Core-Player/Share/Components/MarqueeText.swift
+++ b/Night-Core-Player/Share/Components/MarqueeText.swift
@@ -16,12 +16,12 @@ struct MarqueeText: View {
     let speed: Double               // pt／秒
     let spacingBetweenTexts: CGFloat
     let delayBeforeScroll: Double   // 秒
-    
+
     @State private var contentWidth: CGFloat = 0
     @State private var isAnimating: Bool = false
 
     let selectedTab: PlayerNavigator.Tab
-    
+
     init(
         text: String,
         font: Font = .body,
@@ -41,20 +41,20 @@ struct MarqueeText: View {
         self.delayBeforeScroll = delayBeforeScroll
         self.selectedTab = selectedTab
     }
-    
+
     private var shouldScroll: Bool {
         contentWidth > visibleWidth
     }
-    
+
     private var animationDuration: Double {
         guard shouldScroll, speed > 0 else { return 0 }
         return (contentWidth + spacingBetweenTexts) / speed
     }
-    
+
     var body: some View {
         GeometryReader { geo in
             let currentVisibleWidth = min(visibleWidth, geo.size.width)
-            
+
             ZStack(alignment: .leading) {
                 Text(text)
                     .font(font)
@@ -68,7 +68,7 @@ struct MarqueeText: View {
                         }
                     )
                     .hidden()
-                
+
                 if shouldScroll {
                     HStack(spacing: spacingBetweenTexts) {
                         Text(text).font(font).lineLimit(1).fixedSize(horizontal: true, vertical: false)
@@ -103,7 +103,7 @@ struct MarqueeText: View {
             }
         }
     }
-    
+
     private func restartAnimation() {
         guard contentWidth > visibleWidth, speed > 0 else { return }
         withAnimation(.none) {

--- a/Night-Core-Player/Share/Components/SongContextMenu.swift
+++ b/Night-Core-Player/Share/Components/SongContextMenu.swift
@@ -4,7 +4,7 @@ import MusicKit
 struct SongContextMenu: View {
     let song: Song
     @Environment(MusicPlayerViewModel.self) private var playerVM
-    
+
     var body: some View {
         Menu {
             Button {

--- a/Night-Core-Player/Share/Utilities/KeyboardResponder.swift
+++ b/Night-Core-Player/Share/Utilities/KeyboardResponder.swift
@@ -6,7 +6,7 @@ import Observation
 final class KeyboardResponder {
     var isVisible: Bool = false
     private var cancellables = Set<AnyCancellable>()
-    
+
     init() {
         let willShow = NotificationCenter.default
             .publisher(for: UIResponder.keyboardWillShowNotification)
@@ -14,7 +14,7 @@ final class KeyboardResponder {
         let willHide = NotificationCenter.default
             .publisher(for: UIResponder.keyboardWillHideNotification)
             .map { _ in false }
-        
+
         Publishers.Merge(willShow, willHide)
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.isVisible = $0 }

--- a/Night-Core-PlayerTests/.swiftlint.yml
+++ b/Night-Core-PlayerTests/.swiftlint.yml
@@ -1,0 +1,22 @@
+# 親 .swiftlint.yml とマージされるテスト向け緩和（nested configuration）
+#
+# 緩和の根拠:
+#   - force_try      : makeDummyData.swift が JSONDecoder().decode を try! で利用している
+#   - file_length    : MusicPlayerServiceTests.swift が 969 行（Given-When-Then を1メソッドで書く方針のため長くなる）
+#   - identifier_name: テスト内の一時変数に短い名前を使えるようにする
+#   - comma          : #expect(x == ["A","B","C"]) のようなリテラル内のコンパクトな書き方を許容する
+#   - large_tuple    : Mock の引数記録やアサーションで多要素タプルを使えるようにする
+#   - type_name      : MusicKitServiceMock_Search のような _ 区切りのグルーピング名を許容する
+
+disabled_rules:
+  - force_try
+  - force_cast
+  - identifier_name
+  - file_length
+  - function_body_length
+  - type_body_length
+  - cyclomatic_complexity
+  - comma
+  - non_optional_string_data_conversion
+  - large_tuple
+  - type_name

--- a/Night-Core-PlayerTests/Features/MusicPlayer/MusicPlayerViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/MusicPlayer/MusicPlayerViewModelTests.swift
@@ -32,21 +32,21 @@ struct MusicPlayerViewModelTests {
         let cancel = svc.snapshotSubject.sink { _ in }
         return (vm, svc, cancel)
     }
-    
+
     @Test("初期化: プロパティが初期値であること")
     func init_default_hasInitialValues() {
         // Given
         let (vm, _, cancel) = MusicPlayerViewModelTests.setUp()
         // Then
-        #expect(vm.title      == "—",                             "タイトルの初期値")
-        #expect(vm.artist     == "—",                             "アーティストの初期値")
-        #expect(vm.currentTime == 0,                              "currentTimeの初期値")
-        #expect(vm.duration    == 0,                              "durationの初期値")
+        #expect(vm.title      == "—", "タイトルの初期値")
+        #expect(vm.artist     == "—", "アーティストの初期値")
+        #expect(vm.currentTime == 0, "currentTimeの初期値")
+        #expect(vm.duration    == 0, "durationの初期値")
         #expect(vm.rate        == Constants.MusicPlayer.defaultPlaybackRate, "rateの初期値")
-        #expect(vm.isPlaying   == false,                          "isPlayingの初期値")
+        #expect(vm.isPlaying   == false, "isPlayingの初期値")
         cancel.cancel()
     }
-    
+
     @Test("playPauseTrack: isPlaying=falseの時play()が呼ばれること")
     func playPauseTrack_notPlaying_callsPlay() async {
         // Given
@@ -59,7 +59,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.pauseCallCount == 0, "pause()は呼ばれない")
         cancel.cancel()
     }
-    
+
     @Test("playPauseTrack: isPlaying=trueの時pause()が呼ばれること")
     func playPauseTrack_isPlaying_callsPause() async {
         // Given
@@ -81,7 +81,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.playCallCount  == 0, "play()は呼ばれない")
         cancel.cancel()
     }
-    
+
     @Test("nextTrack: next()が呼ばれること")
     func nextTrack_called_callsServiceNext() async {
         // Given
@@ -93,7 +93,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.nextCallCount == 1, "next()が１回呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("previousTrack: previous()が呼ばれること")
     func previousTrack_called_callsServicePrevious() async {
         // Given
@@ -105,7 +105,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.previousCallCount == 1, "previous()が１回呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("rewind15: currentTime=10の時seek(0)が呼ばれること")
     func rewind15_nearStart_seeksToZero() async {
         // Given
@@ -126,7 +126,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.seekArgs.last == 0, "seek(0)が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("rewind15: currentTime=30の時seek(15)が呼ばれること")
     func rewind15_normal_seeksBack15() async {
         // Given
@@ -147,7 +147,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.seekArgs.last == 15, "seek(15)が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("forward15: currentTime=50,duration=60の時seek(60)が呼ばれること")
     func forward15_nearEnd_seeksToEnd() async {
         // Given
@@ -168,7 +168,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.seekArgs.last == 60, "seek(60)が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("forward15: currentTime=20,duration=60の時seek(35)が呼ばれること")
     func forward15_normal_seeksForward15() async {
         // Given
@@ -189,7 +189,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.seekArgs.last == 35, "seek(35)が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("seek: 任意時間にseek(to:)が呼ばれること")
     func seek_anyTime_callsServiceSeek() async {
         // Given
@@ -201,7 +201,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.seekArgs.last == 42, "seek(42)が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("setRate: 範囲外は補正してsetSessionRate()が呼ばれること")
     func setRate_outOfRange_clampsToMinMax() async {
         // Given
@@ -226,7 +226,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.rateArgs.last == Constants.MusicPlayer.maxPlaybackRate, "setSessionRate(max)が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("setRate: 有効値ならsetSessionRate()が呼ばれること")
     func setRate_validValue_setsRate() async {
         // Given
@@ -242,7 +242,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.rateArgs.last == 1.5, "setSessionRate(1.5)が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("adjustRate(by:): rate が増加され、service.setSessionRate() が呼ばれること")
     func adjustRate_increment_updatesRateAndService() async {
         // Given
@@ -256,7 +256,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.rateArgs.last == base + 0.2, "service.setSessionRate(\(base + 0.2)) が呼ばれること")
         cancel.cancel()
     }
-    
+
     @Test("adjustRate(by:): rate 増加が上限を超えると最大値にクランプされること")
     func adjustRate_exceedsMax_clampedToMax() async {
         // Given
@@ -272,7 +272,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.rateArgs.last == Constants.MusicPlayer.maxPlaybackRate, "service.setSessionRate(max) が呼ばれること")
         cancel.cancel()
     }
-    
+
     @Test("loadPlaylist: autoPlay=falseならplay()されないこと")
     func loadPlaylist_autoPlayFalse_noPlay() async {
         // Given
@@ -290,7 +290,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.playCallCount     == 0, "play()は呼ばれない")
         cancel.cancel()
     }
-    
+
     @Test("loadPlaylist: autoPlay=trueでplay()が呼ばれること")
     func loadPlaylist_autoPlayTrue_callsPlay() async {
         // Given
@@ -307,7 +307,7 @@ struct MusicPlayerViewModelTests {
         #expect(svc.playCallCount == 1, "play()が呼ばれる")
         cancel.cancel()
     }
-    
+
     @Test("setQueue: 指定された楽曲が選択された場合、当該楽曲を再生すること")
     func setQueue_withStartAt_updatesQueueAndIndex() async {
         // Given
@@ -318,7 +318,7 @@ struct MusicPlayerViewModelTests {
         await MusicPlayerViewModelTests.waitUntil { vm.musicPlayerQueue == songs }
         // Then
         #expect(vm.musicPlayerQueue == songs, "musicPlayerQueue が setQueue の内容になること")
-        #expect(vm.currentIndex     == 2,     "currentIndex が startAt=2 になること")
+        #expect(vm.currentIndex     == 2, "currentIndex が startAt=2 になること")
         cancel.cancel()
     }
 
@@ -334,7 +334,7 @@ struct MusicPlayerViewModelTests {
                 "moveItem(from:2, to:2) が呼ばれること")
         cancel.cancel()
     }
-    
+
     @Test("removeQueueItem: service.removeItem(at:) が呼ばれること")
     func removeQueueItem_singleIndex_callsServiceRemove() async {
         // Given
@@ -347,7 +347,7 @@ struct MusicPlayerViewModelTests {
                 "removeItem(at:3) が呼ばれること")
         cancel.cancel()
     }
-    
+
     @Test("removeQueueItem (batch): 複数のオフセットから降順で service.removeItem(at:) が呼ばれること")
     func removeQueueItem_multipleIndexes_removesDescending() async {
         // Given
@@ -374,10 +374,10 @@ struct MusicPlayerViewModelTests {
         await MusicPlayerViewModelTests.waitUntil { vm.musicPlayerQueue == [B] }
         // Then
         #expect(vm.musicPlayerQueue == [B], "playNow 後にキューが [B] のみになること")
-        #expect(vm.currentIndex     == 0,   "currentIndex が0になること")
+        #expect(vm.currentIndex     == 0, "currentIndex が0になること")
         cancel.cancel()
     }
-    
+
     @Test("playNowNext: playNextAndPlay() が呼び出されること")
     func playNowNext_song_callsService() async {
         // Given
@@ -391,7 +391,7 @@ struct MusicPlayerViewModelTests {
                 "playNextAndPlay(_:) が１回だけ呼ばれること")
         cancel.cancel()
     }
-    
+
     @Test("playNowNext: サービスの状態を VM に反映すること")
     func playNowNext_song_syncsQueueAndIndex() async {
         // Given
@@ -409,7 +409,7 @@ struct MusicPlayerViewModelTests {
                 "VM.currentIndex がサービスのインデックスと一致すること")
         cancel.cancel()
     }
-    
+
     @Test("insertNext: 次の曲に割り込みで追加されること")
     func insertNext_song_insertsAfterCurrent() async {
         // Given
@@ -428,7 +428,7 @@ struct MusicPlayerViewModelTests {
         #expect(vm.currentIndex == 0, "現在再生中の楽曲（currentIndex） は元のまま0のこと")
         cancel.cancel()
     }
-    
+
     @Test("clearHistory: 実行後に history が空になること")
     func clearHistory_withHistory_clearsAll() async {
         // Given
@@ -445,7 +445,7 @@ struct MusicPlayerViewModelTests {
         #expect(vm.history.isEmpty, "clearHistory 後に history が空になること")
         cancel.cancel()
     }
-    
+
     @Test("snapshot受信: プロパティが更新されること")
     func snapshotReceived_validSnapshot_updatesProperties() async {
         // Given
@@ -463,15 +463,15 @@ struct MusicPlayerViewModelTests {
         svc.snapshotSubject.send(snap)
         await MusicPlayerViewModelTests.waitUntil { vm.title == "テスト曲" }
         // Then
-        #expect(vm.title       == "テスト曲",               "タイトル更新")
-        #expect(vm.artist      == "アーティスト",           "アーティスト更新")
-        #expect(vm.currentTime == 20,                       "currentTime更新")
-        #expect(vm.duration    == 120,                      "duration更新")
-        #expect(vm.rate        == 1.2,                      "rate更新")
-        #expect(vm.isPlaying   == true,                     "isPlaying更新")
+        #expect(vm.title       == "テスト曲", "タイトル更新")
+        #expect(vm.artist      == "アーティスト", "アーティスト更新")
+        #expect(vm.currentTime == 20, "currentTime更新")
+        #expect(vm.duration    == 120, "duration更新")
+        #expect(vm.rate        == 1.2, "rate更新")
+        #expect(vm.isPlaying   == true, "isPlaying更新")
         cancel.cancel()
     }
-    
+
     @Test("formatRemainingTime: 現在トラックのみ、rate=1.0 のとき正しく計算されること")
     func formatRemainingTime_onlyCurrent_formatsCorrectly() {
         // 残り = 90 - 30 = 60 秒 → rate=1 で 60 秒 → "01:00"
@@ -483,7 +483,7 @@ struct MusicPlayerViewModelTests {
         )
         #expect(result == "01:00", "残り60秒が “01:00” になる")
     }
-    
+
     @Test("formatRemainingTime: 今後のトラックも含め、rate=2.0 のとき正しく計算されること")
     func formatRemainingTime_withUpcomingAndRate_formatsCorrectly() {
         // 現在残り = 70 - 10 = 60 秒、今後 120 秒 → 合計 180 秒
@@ -496,7 +496,7 @@ struct MusicPlayerViewModelTests {
         )
         #expect(result == "01:30", "180 秒 / rate 2 = 90 秒 が “01:30” になる")
     }
-    
+
     @Test("formatRemainingTime: rate=0 のときゼロ除算せずに安全に動くこと")
     func formatRemainingTime_zeroRate_handlesSafely() {
         // (50 - 10) + 30 = 70 秒 → rate がクリップされて 70 秒 → "01:10"
@@ -508,7 +508,7 @@ struct MusicPlayerViewModelTests {
         )
         #expect(result == "01:10", "rate=0 でも “01:10” になる")
     }
-    
+
     @Test("remainingTimeString: ServiceSnapshot を受け取ったあと ViewModel.remainingTimeString が正しく更新されること")
     func remainingTimeString_afterSnapshot_calculatesCorrectly() async {
         // Given

--- a/Night-Core-PlayerTests/Features/Playlist/PlaylistDetailViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Playlist/PlaylistDetailViewModelTests.swift
@@ -38,7 +38,7 @@ struct PlaylistDetailViewModelTests {
         let (viewModel, serviceMock) = PlaylistDetailViewModelTests.setUp()
         let expectedSongs = [
             makeDummySong(id: "1", title: "A"),
-            makeDummySong(id: "2", title: "B"),
+            makeDummySong(id: "2", title: "B")
         ]
         serviceMock.fetchPlaylistSongsResult = .success(expectedSongs)
 

--- a/Night-Core-PlayerTests/Features/Playlist/PlaylistViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Playlist/PlaylistViewModelTests.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import MusicKit
 @testable import Night_Core_Player
 
-
 // MARK: - PlaylistViewModel Tests
 @Suite("PlaylistViewModel Tests")
 @MainActor
@@ -36,7 +35,7 @@ struct PlaylistViewModelTests {
             makeDummyPlaylist(id: "2", name: "P2")
         ]
         let (vm, svc) = PlaylistViewModelTests.setUp()
-        svc.fetchLibraryPlaylistsHandler = { limit in
+        svc.fetchLibraryPlaylistsHandler = { _ in
             return playlists
         }
 
@@ -53,7 +52,7 @@ struct PlaylistViewModelTests {
     func load_failure_setsErrorMessage() async {
         // Given
         let (vm, svc) = PlaylistViewModelTests.setUp()
-        svc.fetchLibraryPlaylistsHandler = { limit in
+        svc.fetchLibraryPlaylistsHandler = { _ in
             throw URLError(.badServerResponse)
         }
 

--- a/Night-Core-PlayerTests/Features/Search/SearchViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Search/SearchViewModelTests.swift
@@ -22,7 +22,7 @@ private func waitUntil(
 @Suite("SearchViewModel Tests", .serialized)
 @MainActor
 struct SearchViewModelTests {
-    
+
     /// 共通セットアップ
     static let testSuiteName = "SearchViewModelTests"
 
@@ -36,7 +36,7 @@ struct SearchViewModelTests {
         let vm  = SearchViewModel(musicKitService: svc, userDefaults: defaults)
         return (vm, svc)
     }
-    
+
     @Test("初期化時: プロパティは全て初期値であること")
     func initialState() {
         // Given
@@ -47,27 +47,27 @@ struct SearchViewModelTests {
         #expect(vm.isLoading == false, "isLoading が false であること")
         #expect(vm.errorMessage == nil, "errorMessage が nil であること")
     }
-    
+
     @Test("空白クエリ: searchSongs を呼ばず songs をクリアすること")
     func blankQuery() async {
         // Given
         let (vm, svc) = SearchViewModelTests.setUp()
-        
+
         // When
         vm.query = "   "
         try? await Task.sleep(nanoseconds: UInt64(Constants.Timing.searchDebounce + 50) * 1_000_000)
-        
+
         // Then
         #expect(svc.searchCallArgs.isEmpty, "searchSongs が呼ばれないこと")
         #expect(vm.songs.isEmpty, "songs が空配列であること")
     }
-    
+
     @Test("検索成功: isLoading の変遷と songs 更新")
     func searchSuccess() async {
         // Given
         let (vm, svc) = SearchViewModelTests.setUp()
         svc.stubSongs = [makeDummySong(id: "S1")]
-        
+
         // When
         vm.query = "  Rock  "
         await waitUntil {
@@ -75,30 +75,30 @@ struct SearchViewModelTests {
                 && vm.songs.count == 1
                 && vm.isLoading == false
         }
-        
+
         // Then
         #expect(svc.searchCallArgs.count == 1, "searchSongs が1回呼ばれること")
         #expect(svc.searchCallArgs.first?.keyword == "Rock", "キーワードの前後空白が除去されていること")
         #expect(vm.isLoading == false, "完了後 isLoading が false であること")
         #expect(vm.songs.count == 1, "songs が更新されること")
     }
-    
+
     @Test("同一クエリ重複入力: removeDuplicates で1回のみ呼ばれること")
     func duplicateQuery() async {
         // Given
         let (vm, svc) = SearchViewModelTests.setUp()
         svc.stubSongs = [makeDummySong(id: "S1")]
-        
+
         // When
         vm.query = "Jazz"
         await waitUntil { svc.searchCallArgs.count == 1 }
         vm.query = "Jazz"
         try? await Task.sleep(nanoseconds: UInt64(Constants.Timing.searchDebounce + 150) * 1_000_000)
-        
+
         // Then
         #expect(svc.searchCallArgs.count == 1, "同一クエリは1回のみ検索されること")
     }
-    
+
     @Test("検索失敗: error が設定され songs が空になること")
     func searchError() async {
         // Given

--- a/Night-Core-PlayerTests/Helpers/makeDummyData.swift
+++ b/Night-Core-PlayerTests/Helpers/makeDummyData.swift
@@ -28,7 +28,6 @@ public func makeDummySong(
     return try! JSONDecoder().decode(Song.self, from: data)
 }
 
-
 public func makeDummyArtist(
     id: String = "AR1",
     name: String = "DummyArtist"

--- a/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicKitClientMock.swift
@@ -20,7 +20,7 @@ final class MusicKitClientMock: MusicKitClient, @unchecked Sendable {
     private(set) var fetchArtistSongsCalls: [(limit: Int, offset: Int)] = []
     private(set) var fetchPlaylistCalls: [Int] = []
     private(set) var fetchSongsCalls: [Playlist] = []
-    
+
     func requestAuthorization() async -> MusicAuthorization.Status {
         authorizationRequests += 1
         return authStatus

--- a/Night-Core-PlayerTests/Mock/MusicKitServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicKitServiceMock.swift
@@ -23,7 +23,7 @@ final class MusicKitServiceMock: MusicKitService, @unchecked Sendable {
     // MARK: - Playlist トラッキング
     var fetchLibraryPlaylistsCallCount = 0
     var fetchPlaylistSongsCallCount = 0
-    var fetchLibraryPlaylistsHandler: ((Int) throws -> [Playlist])? = nil
+    var fetchLibraryPlaylistsHandler: ((Int) throws -> [Playlist])?
     var fetchPlaylistSongsResult: Result<[Song], Error> = .success([])
 
     // MARK: - Recommendation トラッキング
@@ -89,4 +89,3 @@ final class MusicKitServiceMock: MusicKitService, @unchecked Sendable {
 // 後方互換エイリアス（テスト移行用、将来削除可）
 typealias MusicKitServiceMock_Search = MusicKitServiceMock
 typealias MusicKitServiceMock_Playlist = MusicKitServiceMock
-

--- a/Night-Core-PlayerTests/Mock/MusicPlayerServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicPlayerServiceMock.swift
@@ -8,10 +8,10 @@ import MediaPlayer
 final class PlayerControllableMock: PlayerControllable {
     var playbackState: MPMusicPlaybackState = .paused
     var currentTime: TimeInterval = 0
-    var nowPlayingItem: MPMediaItem? = nil
+    var nowPlayingItem: MPMediaItem?
     var indexOfNowPlayingItem: Int = 0
     var playbackRate: Double = 1.0
-    
+
     var shuffleMode: MPMusicShuffleMode = .off
     var repeatMode: MPMusicRepeatMode = .none
 
@@ -212,11 +212,11 @@ final class MusicPlayerServiceMock: MusicPlayerService {
     public var musicPlayerQueue: [Song] = []
     public var nowPlayingIndex: Int     = 0
     public var playHistory: [Song]      = []
-    
+
     public private(set) var isShuffled: Bool       = false
     public private(set) var repeatMode: Constants.RepeatMode = .none
     public private(set) var isAutoPlayEnabled: Bool = false
-    
+
     public func start() async {}
 
     public func setQueue(songs: [Song], startAt index: Int, autoPlay: Bool) async {
@@ -294,11 +294,11 @@ final class MusicPlayerServiceMock: MusicPlayerService {
         clearHistoryCallCount += 1
         playHistory.removeAll()
     }
-    
+
     public func toggleShuffle() async {
         isShuffled.toggle()
     }
-    
+
     public func cycleRepeatMode() async {
         switch repeatMode {
         case .none: repeatMode = .all
@@ -306,7 +306,7 @@ final class MusicPlayerServiceMock: MusicPlayerService {
         case .one:  repeatMode = .none
         }
     }
-    
+
     public func toggleAutoPlay() async {
         isAutoPlayEnabled.toggle()
     }

--- a/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
@@ -106,7 +106,7 @@ struct MusicQueueManagerTests {
         let action = await mgr.moveItem(from: 1, to: 1)
         // Then: noActionが返り、順序もcurrentIndexも変わらない
         #expect(action == .noAction)
-        #expect(mgr.items.map(\.id.rawValue) == ["A","B","C"])
+        #expect(mgr.items.map(\.id.rawValue) == ["A", "B", "C"])
         #expect(mgr.currentIndex == 1)
     }
 
@@ -122,7 +122,7 @@ struct MusicQueueManagerTests {
         let action = await mgr.moveItem(from: 1, to: 0)
         // Then: updatePlayerQueueOnlyが返り、Bが先頭に
         #expect(action == .updatePlayerQueueOnly)
-        #expect(mgr.items.map(\.id.rawValue) == ["B","A","C"])
+        #expect(mgr.items.map(\.id.rawValue) == ["B", "A", "C"])
     }
 
     @Test("moveItem: 楽曲を後方に移動できること")
@@ -139,7 +139,7 @@ struct MusicQueueManagerTests {
         let action = await mgr.moveItem(from: 0, to: 2)
         // Then: updatePlayerQueueOnlyが返り、Aが末尾に
         #expect(action == .updatePlayerQueueOnly)
-        #expect(mgr.items.map(\.id.rawValue) == ["B","C","A"])
+        #expect(mgr.items.map(\.id.rawValue) == ["B", "C", "A"])
     }
 
     @Test("moveItem: 非再生中の曲を移動すると即時再生操作は呼ばれず、フラグだけ立つ")
@@ -149,7 +149,7 @@ struct MusicQueueManagerTests {
         let A = makeDummySong(id: "A")
         let B = makeDummySong(id: "B")
         let C = makeDummySong(id: "C")
-        await sut.service.setQueue(songs: [A,B,C], startAt: 0)
+        await sut.service.setQueue(songs: [A, B, C], startAt: 0)
         let beforeSet = sut.adapter.setQueueDescriptors.count
         let beforeSeek = sut.adapter.seekArgs.count
         // When
@@ -179,7 +179,6 @@ struct MusicQueueManagerTests {
         #expect(sut.service.musicPlayerQueue.map(\.id.rawValue) == ["A", "C", "D", "B"], "内部キューは更新済み")
     }
 
-
     @Test("removeItem: 1曲のみなら playerShouldStop")
     func testRemoveItemSingle() async {
         // Given: 1曲だけのキュー
@@ -205,7 +204,7 @@ struct MusicQueueManagerTests {
         let (action, _) = await mgr.removeItem(at: 1)
         // Then: playNewQueueが返り、キュー・indexが更新
         #expect(action == .playNewQueue)
-        #expect(mgr.items.map(\.id.rawValue) == ["A","C"])
+        #expect(mgr.items.map(\.id.rawValue) == ["A", "C"])
         #expect(mgr.currentIndex == 1)
     }
 
@@ -214,12 +213,12 @@ struct MusicQueueManagerTests {
         let A = makeDummySong(id: "A")
         let B = makeDummySong(id: "B")
         let C = makeDummySong(id: "C")
-        
+
         let adapter   = PlayerControllableMock()
         let queueMock = QueueManagingMock()
         queueMock.items = [A, B, C]
         queueMock.currentIndex = 0
-        
+
         let context = AppDataStore.shared.container.mainContext
         let repo = PlayerStateRepository(context: context)
         let historyRepo = HistoryRepository(context: context)
@@ -229,9 +228,9 @@ struct MusicQueueManagerTests {
             historyManager: PlayHistoryManagerImpl(historyRepo: historyRepo),
             artworkService: ArtworkCacheServiceImpl(),
             playerAdapter: adapter,
-            queueManager:  queueMock
+            queueManager: queueMock
         )
-        
+
         // Given
         let beforeSet  = adapter.setQueueDescriptors.count
         let beforeStop = adapter.stopCount
@@ -244,7 +243,6 @@ struct MusicQueueManagerTests {
                 "範囲外なら stop() も呼ばれない")
     }
 
-
     @Test("insertNext: 空キューに追加すると playNewQueue")
     func testInsertNextEmpty() async {
         // Given: 空のキュー
@@ -256,7 +254,7 @@ struct MusicQueueManagerTests {
         #expect(mgr.items.count == 1)
         #expect(mgr.currentIndex == 0)
     }
-    
+
     @Test("playNextAndPlay: キュー内の曲を移動して再生する")
     func testPlayNextAndPlayWhenSongInQueue() async {
         // Given
@@ -266,10 +264,10 @@ struct MusicQueueManagerTests {
         let C = makeDummySong(id: "C")
         sut.queueMock.items = [A, B, C]
         sut.queueMock.currentIndex = 1
-        
+
         // When
         await sut.service.playNextAndPlay(B)
-        
+
         // Then: QueueManagingMock にセットされたキューと index を検証
         #expect(sut.queueMock.items.map(\.id.rawValue) == ["A", "C", "B"])
         #expect(sut.queueMock.currentIndex == 2)
@@ -279,7 +277,7 @@ struct MusicQueueManagerTests {
         #expect(sut.adapter.playCount == 1,
                 "1回 play() が呼ばれる")
     }
-    
+
     @Test("playNextAndPlay: キュー外の曲を挿入して再生する")
     func testPlayNextAndPlayWhenSongNotInQueue() async {
         // Given
@@ -290,10 +288,10 @@ struct MusicQueueManagerTests {
         let D = makeDummySong(id: "D")
         sut.queueMock.items = [A, B, C]
         sut.queueMock.currentIndex = 0
-        
+
         // When
         await sut.service.playNextAndPlay(D)
-        
+
         // Then: QueueManagingMock にセットされたキューと index を検証
         #expect(sut.queueMock.items.map(\.id.rawValue) == ["A", "D", "B", "C"])
         #expect(sut.queueMock.currentIndex == 1)
@@ -302,7 +300,7 @@ struct MusicQueueManagerTests {
         #expect(sut.adapter.playCount == 1,
                 "1回 play() が呼ばれる")
     }
-    
+
     @Test("advanceToNextTrack: 次の曲がない場合は何もしないこと")
     func testAdvanceOutOfRange() async {
         // Given: 1曲だけのキュー
@@ -384,7 +382,7 @@ struct MusicQueueManagerTests {
         // When: songsForPlayerQueueDescriptorを呼ぶ
         let list = await mgr.songsForPlayerQueueDescriptor()
         // Then: indexから末尾までの配列が返る（ローテーションなし）
-        #expect(list.map(\.id.rawValue) == ["B","C"])
+        #expect(list.map(\.id.rawValue) == ["B", "C"])
     }
 }
 
@@ -626,20 +624,20 @@ struct MusicPlayerServiceImplTests {
 
     @Test("removeItem: 非再生中の曲を削除すると、trackChanged 後に adapter.setQueue + seek が呼ばれる")
     func testRemoveItemNonCurrentWithTrackChanged() async {
-        //-- Setup
+        // -- Setup
         let sut   = SUT.make()
         let A     = makeDummySong(id: "A")
         let B     = makeDummySong(id: "B")
         let C     = makeDummySong(id: "C")
         // A(0) を再生中としてセット
         await sut.service.setQueue(songs: [A, B, C], startAt: 0)
-        
+
         let beforeSet  = sut.adapter.setQueueDescriptors.count
-        
-        //-- 実行：非再生中の曲を削除（フラグだけ立つ）
+
+        // -- 実行：非再生中の曲を削除（フラグだけ立つ）
         await sut.service.removeItem(at: 2)
-        
-        //-- trackChanged() をシミュレートするための通知発火
+
+        // -- trackChanged() をシミュレートするための通知発火
         // 1) adapterの indexOfNowPlayingItem が queueMock.currentIndex と一致するようにする
         sut.adapter.indexOfNowPlayingItem = sut.queueMock.currentIndex
         // 2) 曲変更通知をポスト
@@ -649,8 +647,8 @@ struct MusicPlayerServiceImplTests {
         )
         // 非同期後処理が回るのを少しだけ待機
         try? await Task.sleep(nanoseconds: 100_000_000)
-        
-        //-- 検証
+
+        // -- 検証
         #expect(sut.adapter.setQueueDescriptors.count == beforeSet + 1,
                 "非再生中 remove 後の trackChanged で adapter.setQueue(with:) が呼ばれる")
         #expect(sut.adapter.seekArgs.last == 0,
@@ -664,7 +662,7 @@ struct MusicPlayerServiceImplTests {
         let A = makeDummySong(id: "A")
         let B = makeDummySong(id: "B")
         let C = makeDummySong(id: "C")
-        await sut.service.setQueue(songs: [A,B,C], startAt: 1)
+        await sut.service.setQueue(songs: [A, B, C], startAt: 1)
         let beforeSet = sut.adapter.setQueueDescriptors.count
         let beforePlay = sut.adapter.playCount
         // When: B(1)を削除
@@ -744,7 +742,7 @@ struct MusicPlayerServiceImplTests {
         #expect(sut.adapter.shuffleMode == .off, "player.shuffleMode は .off のまま")
         #expect(!sut.service.isShuffled, "isShuffled が false に戻る")
         // 元の順序に復元される
-        #expect(sut.service.musicPlayerQueue.map(\.id.rawValue) == ["A","B","C"],
+        #expect(sut.service.musicPlayerQueue.map(\.id.rawValue) == ["A", "B", "C"],
                 "元のキュー順が復元される")
     }
 
@@ -805,7 +803,7 @@ struct MusicPlayerServiceImplTests {
         #expect(sut.adapter.prepareToPlayCount == 0, "自然な曲送りでは prepare しない")
         #expect(sut.adapter.playCount == 0, "自然な曲送りでは play を再度呼ばない")
     }
-    
+
     @Test("cycleRepeatMode: none→all→one→none の順に切り替わること")
     func testCycleRepeatMode() async {
         let sut = SUT.make()
@@ -814,12 +812,12 @@ struct MusicPlayerServiceImplTests {
         #expect(sut.service.repeatMode == .none)
         // none → all
         await sut.service.cycleRepeatMode()
-        #expect(sut.adapter.repeatMode == .all,  "adapter.repeatMode が .all に")
-        #expect(sut.service.repeatMode == .all,  "service.repeatMode が .all に")
+        #expect(sut.adapter.repeatMode == .all, "adapter.repeatMode が .all に")
+        #expect(sut.service.repeatMode == .all, "service.repeatMode が .all に")
         // all → one
         await sut.service.cycleRepeatMode()
-        #expect(sut.adapter.repeatMode == .one,  "adapter.repeatMode が .one に")
-        #expect(sut.service.repeatMode == .one,  "service.repeatMode が .one に")
+        #expect(sut.adapter.repeatMode == .one, "adapter.repeatMode が .one に")
+        #expect(sut.service.repeatMode == .one, "service.repeatMode が .one に")
         // one → none
         await sut.service.cycleRepeatMode()
         #expect(sut.adapter.repeatMode == .none, "adapter.repeatMode が .none に戻る")

--- a/Night-Core-PlayerTests/Services/PlayHistoryManagerTests.swift
+++ b/Night-Core-PlayerTests/Services/PlayHistoryManagerTests.swift
@@ -98,7 +98,7 @@ struct PlayHistoryManagerTests {
         let songs = [
             makeDummySong(id: "r-1", title: "Restored 1"),
             makeDummySong(id: "r-2", title: "Restored 2"),
-            makeDummySong(id: "r-3", title: "Restored 3"),
+            makeDummySong(id: "r-3", title: "Restored 3")
         ]
 
         manager.restoreHistory(songs)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,30 @@
+# setup: lefthook install
+
+pre-commit:
+  commands:
+    swiftlint:
+      glob: "*.swift"
+      run: swiftlint lint --strict {staged_files}
+    gitleaks:
+      run: gitleaks protect --staged -v
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: |
+        msg="$(head -n 1 {1})"
+        # マージ / リバート / fixup はチェック対象外
+        case "$msg" in
+          Merge*|Revert*|"fixup!"*|"squash!"*) exit 0 ;;
+        esac
+        if ! printf '%s' "$msg" | grep -Eq '^(feat|fix|docs|style|refactor|test|chore)(\([A-Za-z0-9/_-]+\))?!?: .+'; then
+          echo ""
+          echo "[conventional-commit] コミットメッセージが規約に一致しません"
+          echo ""
+          echo "  形式:  <type>(<scope>)?!: <subject>"
+          echo "  type:  feat | fix | docs | style | refactor | test | chore"
+          echo ""
+          echo "  例:    feat: アーティスト検索機能を追加"
+          echo ""
+          exit 1
+        fi


### PR DESCRIPTION
## 概要
#70 の第1段: 設定ファイル群の導入と既存違反の自動修正。

- `.swiftlint.yml`: 既存コードの実測値ベースのしきい値（line 160 / file 800）、opt-in低ノイズルール、`print`禁止custom rule（os.Logger推奨）
- `Night-Core-PlayerTests/.swiftlint.yml`: nested configurationでテスト向け緩和
- `.swiftformat`: 既存スタイル準拠の控えめ構成（testable-bottom import等）
- `lefthook.yml`: pre-commit（swiftlint --strict変更分のみ + gitleaks）、commit-msg（conventional commits検証）
- `Makefile`: check / build / lint / test / format

2コミット目は `swiftlint --fix` の機械適用のみ（空白系290→44件）。残44件はprint使用・ネスト等でコード変更を伴うため #69 リファクタで対応。

## 検証
- ビルド: BUILD SUCCEEDED（Xcode 16.3 / iPhone SE simulator）
- テスト: 全green（fix適用後に再実行済み）

## 残作業（#70内・別PR）
- .claude/rules・hooks整備
- swiftformat のNix導入（未導入のためMakefileの swiftformat-lint は現状スキップ）

refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)