### PR TITLE
feat: 時間残高システムのドメイン層 (#60)

### DIFF
--- a/Night-Core-Player/Core/BusinessConstants.swift
+++ b/Night-Core-Player/Core/BusinessConstants.swift
@@ -38,4 +38,11 @@ public enum Constants {
     public enum Recommendation {
         public static let defaultLimit: Int = 25
     }
+
+    public enum Allowance {
+        public static let trialDays: Int = 7
+        public static let dailyFreeSeconds: TimeInterval = 3600
+        public static let rewardSeconds: TimeInterval = 1800
+        public static let proPromptRewardCount: Int = 5
+    }
 }

--- a/Night-Core-Player/Data/AppDataStore.swift
+++ b/Night-Core-Player/Data/AppDataStore.swift
@@ -9,7 +9,8 @@ struct AppDataStore {
         do {
             container = try ModelContainer(
                 for: PlayerStateEntity.self,
-                HistoryEntity.self
+                HistoryEntity.self,
+                AllowanceEntity.self
             )
         } catch {
             // スキーマ変更で旧 DB と互換性がない場合、ストアを削除して再作成
@@ -17,7 +18,8 @@ struct AppDataStore {
             do {
                 container = try ModelContainer(
                     for: PlayerStateEntity.self,
-                    HistoryEntity.self
+                    HistoryEntity.self,
+                    AllowanceEntity.self
                 )
             } catch {
                 fatalError("SwiftData ModelContainer の初期化に失敗しました: \(error)")

--- a/Night-Core-Player/Data/Entities/AllowanceEntity.swift
+++ b/Night-Core-Player/Data/Entities/AllowanceEntity.swift
@@ -6,7 +6,7 @@ final class AllowanceEntity {
     @Attribute(.unique) var id: String = "default"
 
     var firstLaunchAt: Date
-    var lastResetDayKey: String
+    var nextResetAt: Date
     var remainingSeconds: Double
     var lastSeenAt: Date
     var rewardCountTotal: Int
@@ -14,14 +14,14 @@ final class AllowanceEntity {
 
     init(
         firstLaunchAt: Date,
-        lastResetDayKey: String,
+        nextResetAt: Date,
         remainingSeconds: Double = Constants.Allowance.dailyFreeSeconds,
         lastSeenAt: Date,
         rewardCountTotal: Int = 0,
         proPromptShown: Bool = false
     ) {
         self.firstLaunchAt = firstLaunchAt
-        self.lastResetDayKey = lastResetDayKey
+        self.nextResetAt = nextResetAt
         self.remainingSeconds = remainingSeconds
         self.lastSeenAt = lastSeenAt
         self.rewardCountTotal = rewardCountTotal

--- a/Night-Core-Player/Data/Entities/AllowanceEntity.swift
+++ b/Night-Core-Player/Data/Entities/AllowanceEntity.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftData
+
+@Model
+final class AllowanceEntity {
+    @Attribute(.unique) var id: String = "default"
+
+    var firstLaunchAt: Date
+    var lastResetDayKey: String
+    var remainingSeconds: Double
+    var lastSeenAt: Date
+    var rewardCountTotal: Int
+    var proPromptShown: Bool
+
+    init(
+        firstLaunchAt: Date,
+        lastResetDayKey: String,
+        remainingSeconds: Double = Constants.Allowance.dailyFreeSeconds,
+        lastSeenAt: Date,
+        rewardCountTotal: Int = 0,
+        proPromptShown: Bool = false
+    ) {
+        self.firstLaunchAt = firstLaunchAt
+        self.lastResetDayKey = lastResetDayKey
+        self.remainingSeconds = remainingSeconds
+        self.lastSeenAt = lastSeenAt
+        self.rewardCountTotal = rewardCountTotal
+        self.proPromptShown = proPromptShown
+    }
+}

--- a/Night-Core-Player/Data/Repositories/AllowanceRepository.swift
+++ b/Night-Core-Player/Data/Repositories/AllowanceRepository.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SwiftData
+
+final class AllowanceRepository {
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+    }
+
+    func loadOrCreate(now: Date, dayKey: String) throws -> AllowanceSnapshot {
+        if let e = try fetch() {
+            return AllowanceSnapshot(
+                firstLaunchAt: e.firstLaunchAt,
+                lastResetDayKey: e.lastResetDayKey,
+                remainingSeconds: e.remainingSeconds,
+                lastSeenAt: e.lastSeenAt,
+                rewardCountTotal: e.rewardCountTotal,
+                proPromptShown: e.proPromptShown
+            )
+        }
+        let entity = AllowanceEntity(
+            firstLaunchAt: now,
+            lastResetDayKey: dayKey,
+            lastSeenAt: now
+        )
+        context.insert(entity)
+        try context.save()
+        return AllowanceSnapshot(
+            firstLaunchAt: entity.firstLaunchAt,
+            lastResetDayKey: entity.lastResetDayKey,
+            remainingSeconds: entity.remainingSeconds,
+            lastSeenAt: entity.lastSeenAt,
+            rewardCountTotal: entity.rewardCountTotal,
+            proPromptShown: entity.proPromptShown
+        )
+    }
+
+    func save(_ snapshot: AllowanceSnapshot) throws {
+        guard let e = try fetch() else {
+            let entity = AllowanceEntity(
+                firstLaunchAt: snapshot.firstLaunchAt,
+                lastResetDayKey: snapshot.lastResetDayKey,
+                remainingSeconds: snapshot.remainingSeconds,
+                lastSeenAt: snapshot.lastSeenAt,
+                rewardCountTotal: snapshot.rewardCountTotal,
+                proPromptShown: snapshot.proPromptShown
+            )
+            context.insert(entity)
+            try context.save()
+            return
+        }
+        e.firstLaunchAt = snapshot.firstLaunchAt
+        e.lastResetDayKey = snapshot.lastResetDayKey
+        e.remainingSeconds = snapshot.remainingSeconds
+        e.lastSeenAt = snapshot.lastSeenAt
+        e.rewardCountTotal = snapshot.rewardCountTotal
+        e.proPromptShown = snapshot.proPromptShown
+        try context.save()
+    }
+
+    func reset() throws {
+        if let e = try fetch() {
+            context.delete(e)
+            try context.save()
+        }
+    }
+
+    private func fetch() throws -> AllowanceEntity? {
+        let descriptor = FetchDescriptor<AllowanceEntity>(
+            predicate: #Predicate { $0.id == "default" }
+        )
+        return try context.fetch(descriptor).first
+    }
+}

--- a/Night-Core-Player/Data/Repositories/AllowanceRepository.swift
+++ b/Night-Core-Player/Data/Repositories/AllowanceRepository.swift
@@ -8,11 +8,11 @@ final class AllowanceRepository {
         self.context = context
     }
 
-    func loadOrCreate(now: Date, dayKey: String) throws -> AllowanceSnapshot {
+    func loadOrCreate(now: Date) throws -> AllowanceSnapshot {
         if let e = try fetch() {
             return AllowanceSnapshot(
                 firstLaunchAt: e.firstLaunchAt,
-                lastResetDayKey: e.lastResetDayKey,
+                nextResetAt: e.nextResetAt,
                 remainingSeconds: e.remainingSeconds,
                 lastSeenAt: e.lastSeenAt,
                 rewardCountTotal: e.rewardCountTotal,
@@ -21,14 +21,14 @@ final class AllowanceRepository {
         }
         let entity = AllowanceEntity(
             firstLaunchAt: now,
-            lastResetDayKey: dayKey,
+            nextResetAt: now.addingTimeInterval(86400),
             lastSeenAt: now
         )
         context.insert(entity)
         try context.save()
         return AllowanceSnapshot(
             firstLaunchAt: entity.firstLaunchAt,
-            lastResetDayKey: entity.lastResetDayKey,
+            nextResetAt: entity.nextResetAt,
             remainingSeconds: entity.remainingSeconds,
             lastSeenAt: entity.lastSeenAt,
             rewardCountTotal: entity.rewardCountTotal,
@@ -40,7 +40,7 @@ final class AllowanceRepository {
         guard let e = try fetch() else {
             let entity = AllowanceEntity(
                 firstLaunchAt: snapshot.firstLaunchAt,
-                lastResetDayKey: snapshot.lastResetDayKey,
+                nextResetAt: snapshot.nextResetAt,
                 remainingSeconds: snapshot.remainingSeconds,
                 lastSeenAt: snapshot.lastSeenAt,
                 rewardCountTotal: snapshot.rewardCountTotal,
@@ -51,7 +51,7 @@ final class AllowanceRepository {
             return
         }
         e.firstLaunchAt = snapshot.firstLaunchAt
-        e.lastResetDayKey = snapshot.lastResetDayKey
+        e.nextResetAt = snapshot.nextResetAt
         e.remainingSeconds = snapshot.remainingSeconds
         e.lastSeenAt = snapshot.lastSeenAt
         e.rewardCountTotal = snapshot.rewardCountTotal

--- a/Night-Core-Player/Models/Allowance.swift
+++ b/Night-Core-Player/Models/Allowance.swift
@@ -8,7 +8,7 @@ enum PlaybackEntitlement: Equatable, Sendable {
 
 struct AllowanceSnapshot: Equatable, Sendable {
     var firstLaunchAt: Date
-    var lastResetDayKey: String
+    var nextResetAt: Date
     var remainingSeconds: TimeInterval
     var lastSeenAt: Date
     var rewardCountTotal: Int

--- a/Night-Core-Player/Models/Allowance.swift
+++ b/Night-Core-Player/Models/Allowance.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum PlaybackEntitlement: Equatable, Sendable {
+    case trial(endsAt: Date)
+    case free(remaining: TimeInterval)
+    case exhausted
+}
+
+struct AllowanceSnapshot: Equatable, Sendable {
+    var firstLaunchAt: Date
+    var lastResetDayKey: String
+    var remainingSeconds: TimeInterval
+    var lastSeenAt: Date
+    var rewardCountTotal: Int
+    var proPromptShown: Bool
+}

--- a/Night-Core-Player/Services/AllowanceService.swift
+++ b/Night-Core-Player/Services/AllowanceService.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+// MARK: - Protocol
+
+@MainActor
+protocol AllowanceService: Sendable {
+    func entitlement(now: Date) throws -> PlaybackEntitlement
+    func consume(_ seconds: TimeInterval, now: Date) throws
+    func grantReward(now: Date) throws -> TimeInterval
+    func shouldShowProPrompt(now: Date) throws -> Bool
+    func markProPromptShown(now: Date) throws
+}
+
+// MARK: - Impl
+
+@MainActor
+final class AllowanceServiceImpl: AllowanceService {
+    private let repo: AllowanceRepository
+    private let calendar: Calendar
+
+    init(repo: AllowanceRepository, calendar: Calendar = .current) {
+        self.repo = repo
+        self.calendar = calendar
+    }
+
+    func entitlement(now: Date) throws -> PlaybackEntitlement {
+        let snapshot = try normalizedSnapshot(now: now)
+        let trialEnd = trialEndDate(firstLaunchAt: snapshot.firstLaunchAt)
+        if guardedNow(now, snapshot: snapshot) < trialEnd {
+            return .trial(endsAt: trialEnd)
+        }
+        return snapshot.remainingSeconds > 0
+            ? .free(remaining: snapshot.remainingSeconds)
+            : .exhausted
+    }
+
+    func consume(_ seconds: TimeInterval, now: Date) throws {
+        var snapshot = try normalizedSnapshot(now: now)
+        let trialEnd = trialEndDate(firstLaunchAt: snapshot.firstLaunchAt)
+        guard guardedNow(now, snapshot: snapshot) >= trialEnd else { return }
+        snapshot.remainingSeconds = max(0, snapshot.remainingSeconds - max(0, seconds))
+        try repo.save(snapshot)
+    }
+
+    func grantReward(now: Date) throws -> TimeInterval {
+        var snapshot = try normalizedSnapshot(now: now)
+        snapshot.remainingSeconds += Constants.Allowance.rewardSeconds
+        snapshot.rewardCountTotal += 1
+        try repo.save(snapshot)
+        return snapshot.remainingSeconds
+    }
+
+    func shouldShowProPrompt(now: Date) throws -> Bool {
+        let snapshot = try normalizedSnapshot(now: now)
+        return snapshot.rewardCountTotal >= Constants.Allowance.proPromptRewardCount
+            && !snapshot.proPromptShown
+    }
+
+    func markProPromptShown(now: Date) throws {
+        var snapshot = try normalizedSnapshot(now: now)
+        snapshot.proPromptShown = true
+        try repo.save(snapshot)
+    }
+
+    // MARK: - Private
+
+    /// 時計を過去に戻しても lastSeenAt より前には進まない
+    private func guardedNow(_ now: Date, snapshot: AllowanceSnapshot) -> Date {
+        max(now, snapshot.lastSeenAt)
+    }
+
+    private func normalizedSnapshot(now: Date) throws -> AllowanceSnapshot {
+        var snapshot = try repo.loadOrCreate(now: now, dayKey: dayKey(for: now))
+        let guarded = guardedNow(now, snapshot: snapshot)
+        let key = dayKey(for: guarded)
+        if key != snapshot.lastResetDayKey {
+            snapshot.lastResetDayKey = key
+            snapshot.remainingSeconds = Constants.Allowance.dailyFreeSeconds
+        }
+        snapshot.lastSeenAt = guarded
+        try repo.save(snapshot)
+        return snapshot
+    }
+
+    private func trialEndDate(firstLaunchAt: Date) -> Date {
+        calendar.date(
+            byAdding: .day,
+            value: Constants.Allowance.trialDays,
+            to: firstLaunchAt
+        ) ?? firstLaunchAt
+    }
+
+    private func dayKey(for date: Date) -> String {
+        let c = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+}

--- a/Night-Core-Player/Services/AllowanceService.swift
+++ b/Night-Core-Player/Services/AllowanceService.swift
@@ -15,19 +15,21 @@ protocol AllowanceService: Sendable {
 
 @MainActor
 final class AllowanceServiceImpl: AllowanceService {
-    private let repo: AllowanceRepository
-    private let calendar: Calendar
+    private static let daySeconds: TimeInterval = 86400
 
-    init(repo: AllowanceRepository, calendar: Calendar = .current) {
+    /// 実時刻が初回起動より1時間以上過去なら時計改竄とみなす許容幅
+    private static let trialClockToleranceSeconds: TimeInterval = 3600
+
+    private let repo: AllowanceRepository
+
+    init(repo: AllowanceRepository) {
         self.repo = repo
-        self.calendar = calendar
     }
 
     func entitlement(now: Date) throws -> PlaybackEntitlement {
         let snapshot = try normalizedSnapshot(now: now)
-        let trialEnd = trialEndDate(firstLaunchAt: snapshot.firstLaunchAt)
-        if guardedNow(now, snapshot: snapshot) < trialEnd {
-            return .trial(endsAt: trialEnd)
+        if isTrialActive(snapshot: snapshot, now: now) {
+            return .trial(endsAt: trialEndDate(firstLaunchAt: snapshot.firstLaunchAt))
         }
         return snapshot.remainingSeconds > 0
             ? .free(remaining: snapshot.remainingSeconds)
@@ -36,8 +38,7 @@ final class AllowanceServiceImpl: AllowanceService {
 
     func consume(_ seconds: TimeInterval, now: Date) throws {
         var snapshot = try normalizedSnapshot(now: now)
-        let trialEnd = trialEndDate(firstLaunchAt: snapshot.firstLaunchAt)
-        guard guardedNow(now, snapshot: snapshot) >= trialEnd else { return }
+        guard !isTrialActive(snapshot: snapshot, now: now) else { return }
         snapshot.remainingSeconds = max(0, snapshot.remainingSeconds - max(0, seconds))
         try repo.save(snapshot)
     }
@@ -70,28 +71,23 @@ final class AllowanceServiceImpl: AllowanceService {
     }
 
     private func normalizedSnapshot(now: Date) throws -> AllowanceSnapshot {
-        var snapshot = try repo.loadOrCreate(now: now, dayKey: dayKey(for: now))
+        var snapshot = try repo.loadOrCreate(now: now)
         let guarded = guardedNow(now, snapshot: snapshot)
-        let key = dayKey(for: guarded)
-        if key != snapshot.lastResetDayKey {
-            snapshot.lastResetDayKey = key
-            snapshot.remainingSeconds = Constants.Allowance.dailyFreeSeconds
-        }
         snapshot.lastSeenAt = guarded
-        try repo.save(snapshot)
+        if guarded >= snapshot.nextResetAt {
+            snapshot.remainingSeconds = Constants.Allowance.dailyFreeSeconds
+            snapshot.nextResetAt = guarded.addingTimeInterval(Self.daySeconds)
+            try repo.save(snapshot)
+        }
         return snapshot
     }
 
-    private func trialEndDate(firstLaunchAt: Date) -> Date {
-        calendar.date(
-            byAdding: .day,
-            value: Constants.Allowance.trialDays,
-            to: firstLaunchAt
-        ) ?? firstLaunchAt
+    private func isTrialActive(snapshot: AllowanceSnapshot, now: Date) -> Bool {
+        guard now >= snapshot.firstLaunchAt - Self.trialClockToleranceSeconds else { return false }
+        return guardedNow(now, snapshot: snapshot) < trialEndDate(firstLaunchAt: snapshot.firstLaunchAt)
     }
 
-    private func dayKey(for date: Date) -> String {
-        let c = calendar.dateComponents([.year, .month, .day], from: date)
-        return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    private func trialEndDate(firstLaunchAt: Date) -> Date {
+        firstLaunchAt.addingTimeInterval(TimeInterval(Constants.Allowance.trialDays) * Self.daySeconds)
     }
 }

--- a/Night-Core-PlayerTests/Services/AllowanceServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/AllowanceServiceTests.swift
@@ -11,14 +11,13 @@ struct AllowanceServiceTests {
     // MARK: - Helpers
 
     private static let day0 = ISO8601DateFormatter().date(from: "2026-08-01T12:00:00+09:00")!
+    private static let daySeconds: TimeInterval = 86400
 
     private static func makeService() throws -> (service: AllowanceServiceImpl, repo: AllowanceRepository) {
         let context = AppDataStore.shared.container.mainContext
         let repo = AllowanceRepository(context: context)
         try repo.reset()
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
-        let service = AllowanceServiceImpl(repo: repo, calendar: calendar)
+        let service = AllowanceServiceImpl(repo: repo)
         return (service, repo)
     }
 
@@ -53,6 +52,35 @@ struct AllowanceServiceTests {
         let (service, _) = try Self.makeService()
         _ = try service.entitlement(now: Self.day0)
         let state = try service.entitlement(now: Self.afterTrial())
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
+    }
+
+    @Test
+    func trialEnd_exactBoundary_isNotTrial() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let end = Self.day0.addingTimeInterval(TimeInterval(Constants.Allowance.trialDays) * Self.daySeconds)
+
+        guard case .trial = try service.entitlement(now: end.addingTimeInterval(-1)) else {
+            Issue.record("期限1秒前はトライアルであるべき")
+            return
+        }
+
+        let stateAtEnd = try service.entitlement(now: end)
+        if case .trial(let endsAt) = stateAtEnd {
+            Issue.record("境界ちょうどはトライアルではないべき: endsAt=\(endsAt)")
+        }
+    }
+
+    @Test
+    func futureFirstLaunch_trialInvalid() throws {
+        let (service, _) = try Self.makeService()
+        // 初回起動を実時刻より1年未来に偽装して作成
+        let futureLaunch = Self.day0.addingTimeInterval(365 * Self.daySeconds)
+        _ = try service.entitlement(now: futureLaunch)
+
+        // 実時刻が初回起動より過去なのでトライアルではなく free 側に落ちる
+        let state = try service.entitlement(now: Self.day0)
         #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
     }
 
@@ -104,6 +132,24 @@ struct AllowanceServiceTests {
     }
 
     @Test
+    func reset_boundaryExact_resetsOnlyAtNextResetAt() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let start = Self.afterTrial()
+        try service.consume(Constants.Allowance.dailyFreeSeconds, now: start)
+        #expect(try service.entitlement(now: start) == .exhausted)
+
+        // リセット境界の1秒前ではリセットされない
+        let justBeforeReset = start.addingTimeInterval(Self.daySeconds - 1)
+        #expect(try service.entitlement(now: justBeforeReset) == .exhausted)
+
+        // guarded == nextResetAt のちょうど時点でリセットされる
+        let boundary = start.addingTimeInterval(Self.daySeconds)
+        let state = try service.entitlement(now: boundary)
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
+    }
+
+    @Test
     func newDay_rewardBalanceDoesNotCarryOver() throws {
         let (service, _) = try Self.makeService()
         _ = try service.entitlement(now: Self.day0)
@@ -139,6 +185,33 @@ struct AllowanceServiceTests {
         let remaining = try service.grantReward(now: now)
         #expect(remaining == Constants.Allowance.rewardSeconds)
         #expect(try service.entitlement(now: now) == .free(remaining: Constants.Allowance.rewardSeconds))
+    }
+
+    // MARK: - Persistence
+
+    @Test
+    func persistence_survivesServiceRecreation() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let now = Self.afterTrial()
+
+        try service.consume(600, now: now)
+        for _ in 0..<Constants.Allowance.proPromptRewardCount {
+            _ = try service.grantReward(now: now)
+        }
+        try service.markProPromptShown(now: now)
+
+        // Service/Repository を作り直しても状態が維持される
+        let recreatedRepo = AllowanceRepository(context: AppDataStore.shared.container.mainContext)
+        let recreated = AllowanceServiceImpl(repo: recreatedRepo)
+
+        let expectedRemaining =
+            Constants.Allowance.dailyFreeSeconds - 600
+            + Constants.Allowance.rewardSeconds * TimeInterval(Constants.Allowance.proPromptRewardCount)
+        #expect(try recreated.entitlement(now: now) == .free(remaining: expectedRemaining))
+
+        // rewardCountTotal >= 閾値かつ proPromptShown 済なので false であるべき
+        #expect(try recreated.shouldShowProPrompt(now: now) == false)
     }
 
     // MARK: - Pro prompt

--- a/Night-Core-PlayerTests/Services/AllowanceServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/AllowanceServiceTests.swift
@@ -1,0 +1,161 @@
+import Testing
+import Foundation
+import SwiftData
+
+@testable import Night_Core_Player
+
+@Suite("AllowanceService Tests", .serialized)
+@MainActor
+struct AllowanceServiceTests {
+
+    // MARK: - Helpers
+
+    private static let day0 = ISO8601DateFormatter().date(from: "2026-08-01T12:00:00+09:00")!
+
+    private static func makeService() throws -> (service: AllowanceServiceImpl, repo: AllowanceRepository) {
+        let context = AppDataStore.shared.container.mainContext
+        let repo = AllowanceRepository(context: context)
+        try repo.reset()
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        let service = AllowanceServiceImpl(repo: repo, calendar: calendar)
+        return (service, repo)
+    }
+
+    private static func afterTrial(_ days: Int = 8, hours: Double = 0) -> Date {
+        day0.addingTimeInterval(TimeInterval(days) * 86400 + hours * 3600)
+    }
+
+    // MARK: - Trial
+
+    @Test
+    func firstLaunch_startsTrial() throws {
+        let (service, _) = try Self.makeService()
+        let state = try service.entitlement(now: Self.day0)
+        guard case .trial(let endsAt) = state else {
+            Issue.record("trial ではない: \(state)")
+            return
+        }
+        #expect(endsAt > Self.day0)
+    }
+
+    @Test
+    func duringTrial_consumeIsNoOp() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        try service.consume(1800, now: Self.day0.addingTimeInterval(3600))
+        let state = try service.entitlement(now: Self.afterTrial())
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
+    }
+
+    @Test
+    func afterTrial_becomesFreeWithDailyAllowance() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let state = try service.entitlement(now: Self.afterTrial())
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
+    }
+
+    // MARK: - Consume / Exhaust
+
+    @Test
+    func consume_reducesRemaining() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let now = Self.afterTrial()
+        try service.consume(600, now: now)
+        let state = try service.entitlement(now: now)
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds - 600))
+    }
+
+    @Test
+    func consume_toZero_becomesExhausted() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let now = Self.afterTrial()
+        try service.consume(Constants.Allowance.dailyFreeSeconds + 100, now: now)
+        let state = try service.entitlement(now: now)
+        #expect(state == .exhausted)
+    }
+
+    @Test
+    func consume_negativeSeconds_doesNotIncrease() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let now = Self.afterTrial()
+        try service.consume(-500, now: now)
+        let state = try service.entitlement(now: now)
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
+    }
+
+    // MARK: - Daily reset
+
+    @Test
+    func newDay_resetsToDailyAllowance() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let day8 = Self.afterTrial()
+        try service.consume(Constants.Allowance.dailyFreeSeconds, now: day8)
+        #expect(try service.entitlement(now: day8) == .exhausted)
+
+        let day9 = Self.afterTrial(9)
+        let state = try service.entitlement(now: day9)
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
+    }
+
+    @Test
+    func newDay_rewardBalanceDoesNotCarryOver() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let day8 = Self.afterTrial()
+        _ = try service.grantReward(now: day8)
+        let day9 = Self.afterTrial(9)
+        let state = try service.entitlement(now: day9)
+        #expect(state == .free(remaining: Constants.Allowance.dailyFreeSeconds))
+    }
+
+    @Test
+    func backwardClock_doesNotRefill() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let day8 = Self.afterTrial()
+        try service.consume(Constants.Allowance.dailyFreeSeconds, now: day8)
+        #expect(try service.entitlement(now: day8) == .exhausted)
+
+        // 時計を前日に戻しても lastSeenAt でガードされ、リセットされない
+        let day7 = Self.afterTrial(7)
+        let state = try service.entitlement(now: day7)
+        #expect(state == .exhausted)
+    }
+
+    // MARK: - Reward
+
+    @Test
+    func grantReward_addsRewardSeconds() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let now = Self.afterTrial()
+        try service.consume(Constants.Allowance.dailyFreeSeconds, now: now)
+        let remaining = try service.grantReward(now: now)
+        #expect(remaining == Constants.Allowance.rewardSeconds)
+        #expect(try service.entitlement(now: now) == .free(remaining: Constants.Allowance.rewardSeconds))
+    }
+
+    // MARK: - Pro prompt
+
+    @Test
+    func proPrompt_shownOnceAfterThresholdRewards() throws {
+        let (service, _) = try Self.makeService()
+        _ = try service.entitlement(now: Self.day0)
+        let now = Self.afterTrial()
+
+        for i in 0..<Constants.Allowance.proPromptRewardCount {
+            #expect(try service.shouldShowProPrompt(now: now) == false, "\(i)回目で早期表示")
+            _ = try service.grantReward(now: now)
+        }
+        #expect(try service.shouldShowProPrompt(now: now) == true)
+
+        try service.markProPromptShown(now: now)
+        #expect(try service.shouldShowProPrompt(now: now) == false)
+    }
+}


### PR DESCRIPTION
## 概要
フリーミアムの中核となる時間残高システムのドメイン層。設計は #60 のコメント参照。

- `PlaybackEntitlement`: trial(7日) / free(残高) / exhausted の3状態
- 日次リセット: 日付キー変更で残高=3600秒（リワード分の繰越なし）
- リワード付与: +1800秒、累計5回で1回だけPro訴求フラグ
- 時計逆行ガード: guardedNow = max(now, lastSeenAt)。過去戻しでの再リフィル不可
- 全メソッド `now: Date` 注入で実時間非依存

## スコープ外（後続issue）
再生への配線・消費tick (#64)、リワードSDK (#62)、StoreKit (#61)、UI

## 検証
- swiftlint: 新規ファイル0件
- テスト: AllowanceServiceTests 11本 + 既存スイート全green（個別実行でも確認）

closes #60 とはせず、配線完了まで #60 は open 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)