### PR TITLE
feat: 残高消費の再生パイプライン配線と曲境界停止 (#64)

### DIFF
--- a/Night-Core-Player/App.swift
+++ b/Night-Core-Player/App.swift
@@ -38,12 +38,18 @@ struct NightcorePlayerApp: App {
         let historyManager = PlayHistoryManagerImpl(historyRepo: historyRepo)
         let artworkService = ArtworkCacheServiceImpl()
 
+        let allowanceService = AllowanceServiceImpl(
+            repo: AllowanceRepository(context: context)
+        )
+        let allowanceEnforcer = AllowanceEnforcerImpl(allowanceService: allowanceService)
+
         let service = MusicPlayerServiceImpl(
             rateManager: rateManager,
             persistenceService: persistenceService,
             historyManager: historyManager,
             artworkService: artworkService,
-            musicKitService: musicKitService
+            musicKitService: musicKitService,
+            allowanceEnforcer: allowanceEnforcer
         )
 
         playerService = service

--- a/Night-Core-Player/Core/BusinessConstants.swift
+++ b/Night-Core-Player/Core/BusinessConstants.swift
@@ -40,6 +40,10 @@ public enum Constants {
         public static let defaultLimit: Int = 25
     }
 
+    public enum Logging {
+        public static let subsystem: String = "MizuRyu.Night-Core-Player"
+    }
+
     public enum Allowance {
         public static let trialDays: Int = 7
         public static let dailyFreeSeconds: TimeInterval = 3600

--- a/Night-Core-Player/Core/BusinessConstants.swift
+++ b/Night-Core-Player/Core/BusinessConstants.swift
@@ -17,6 +17,7 @@ public enum Constants {
     }
 
     public enum MusicPlayer {
+        public static let normalPlaybackRate: Double = 1.0
         public static let minPlaybackRate: Double = 0.5
         public static let maxPlaybackRate: Double = 3.0
         public static let step: Double = 0.5

--- a/Night-Core-Player/Services/AllowanceEnforcer.swift
+++ b/Night-Core-Player/Services/AllowanceEnforcer.swift
@@ -26,7 +26,7 @@ protocol AllowanceEnforcer: Sendable {
 
 @MainActor
 final class AllowanceEnforcerImpl: AllowanceEnforcer {
-    private let logger = Logger(subsystem: "MizuRyu.Night-Core-Player", category: "Allowance")
+    private let logger = Logger(subsystem: Constants.Logging.subsystem, category: "Allowance")
     /// 前回tickからの経過が異常に長い場合のconsume上限（バックグラウンド放置で残高が一気に飛ぶのを防ぐ）
     private static let maxTickIntervalSeconds: TimeInterval = 60
 

--- a/Night-Core-Player/Services/AllowanceEnforcer.swift
+++ b/Night-Core-Player/Services/AllowanceEnforcer.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Combine
+import os
+
+// Playback: 再生パイプライン内で残高消費と枯渇時の曲境界停止を担う
+
+// MARK: - Event
+
+enum AllowanceEvent: Sendable {
+    case exhaustedPendingSongEnd
+    case stoppedAtSongEnd
+}
+
+// MARK: - Protocol
+
+@MainActor
+protocol AllowanceEnforcer: Sendable {
+    var events: AnyPublisher<AllowanceEvent, Never> { get }
+    var isExhausted: Bool { get }
+    func tick(isPlaying: Bool, rate: Double, now: Date)
+    func shouldStopAtSongBoundary() -> Bool
+    func markStoppedAtSongEnd()
+}
+
+// MARK: - Impl
+
+@MainActor
+final class AllowanceEnforcerImpl: AllowanceEnforcer {
+    private let logger = Logger(subsystem: "MizuRyu.Night-Core-Player", category: "Allowance")
+    /// 前回tickからの経過が異常に長い場合のconsume上限（バックグラウンド放置で残高が一気に飛ぶのを防ぐ）
+    private static let maxTickIntervalSeconds: TimeInterval = 60
+
+    private let allowanceService: AllowanceService
+
+    private let eventSubject = PassthroughSubject<AllowanceEvent, Never>()
+    var events: AnyPublisher<AllowanceEvent, Never> {
+        eventSubject.eraseToAnyPublisher()
+    }
+
+    private var lastTickAt: Date?
+
+    /// entitlement == .exhausted の写し。残高そのものの状態を表し、停止予約とは独立している
+    private var isBalanceExhausted = false
+
+    /// 曲境界での停止予約。「枯滅+再生中+倍速」を観測したときだけアームされる
+    private var pendingStopAtSongEnd = false
+
+    init(allowanceService: AllowanceService) {
+        self.allowanceService = allowanceService
+    }
+
+    var isExhausted: Bool { isBalanceExhausted }
+
+    func tick(isPlaying: Bool, rate: Double, now: Date) {
+        let baseline = lastTickAt ?? now
+        lastTickAt = now
+
+        // 等速再生・素の再生は消費しない。トライアル中かはAllowanceService内部で判定される
+        if isPlaying, rate != Constants.MusicPlayer.normalPlaybackRate {
+            let elapsed = min(max(0, now.timeIntervalSince(baseline)), Self.maxTickIntervalSeconds)
+            if elapsed > 0 {
+                do {
+                    try allowanceService.consume(elapsed, now: now)
+                } catch {
+                    logger.error("Allowance consume error: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        // 残高状態の写しを更新。consume後に判定することで、残高が尽きたtick内で以降の分岐に反映できる
+        if let entitlement = try? allowanceService.entitlement(now: now) {
+            if case .exhausted = entitlement {
+                isBalanceExhausted = true
+            } else {
+                isBalanceExhausted = false
+                // クリア条件: 残高回復時は曲境界での停止予約も解除する
+                pendingStopAtSongEnd = false
+            }
+        }
+
+        // クリア条件: 等速再生を観測したら停止予約を解除する。
+        // 素のApple Music再生（等速）は残高に関係なく一切止めないため
+        if isPlaying, rate == Constants.MusicPlayer.normalPlaybackRate {
+            pendingStopAtSongEnd = false
+            return
+        }
+
+        // アーム条件: 「枯滅+再生中+倍速」のときだけ。false→true遷移時に一度だけイベントを出す。
+        // 枯滅しているだけでは絶対にアームしない
+        if isBalanceExhausted, isPlaying, !pendingStopAtSongEnd {
+            pendingStopAtSongEnd = true
+            eventSubject.send(.exhaustedPendingSongEnd)
+        }
+    }
+
+    func shouldStopAtSongBoundary() -> Bool {
+        pendingStopAtSongEnd
+    }
+
+    func markStoppedAtSongEnd() {
+        guard pendingStopAtSongEnd else { return }
+        pendingStopAtSongEnd = false
+        eventSubject.send(.stoppedAtSongEnd)
+    }
+}

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -3,9 +3,11 @@ import MediaPlayer
 import MusicKit
 import Foundation
 import AVFoundation
+import os
 
 @MainActor
 public final class MusicPlayerServiceImpl: MusicPlayerService {
+    private let logger = Logger(subsystem: "MizuRyu.Night-Core-Player", category: "MusicPlayer")
     @Published public private(set) var snapshot: MusicPlayerSnapshot = .empty
     @Published public private(set) var isShuffled: Bool = false
     @Published public private(set) var repeatMode: Constants.RepeatMode = .none
@@ -34,6 +36,8 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     private let historyManager: PlayHistoryManaging
     private let artworkService: ArtworkCacheService
     private let musicKitService: MusicKitService?
+    private let allowanceEnforcer: AllowanceEnforcer?
+    private let now: () -> Date
 
     var currentPlaybackRate: Double = Constants.MusicPlayer.defaultPlaybackRate
     private let minPlaybackRate: Double = Constants.MusicPlayer.minPlaybackRate
@@ -54,13 +58,17 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         artworkService: ArtworkCacheService,
         musicKitService: MusicKitService? = nil,
         playerAdapter: PlayerControllable? = nil,
-        queueManager: QueueManaging? = nil
+        queueManager: QueueManaging? = nil,
+        allowanceEnforcer: AllowanceEnforcer? = nil,
+        now: @escaping () -> Date = Date.init
     ) {
         self.rateManager = rateManager
         self.persistenceService = persistenceService
         self.historyManager = historyManager
         self.artworkService = artworkService
         self.musicKitService = musicKitService
+        self.allowanceEnforcer = allowanceEnforcer
+        self.now = now
 
         self.player   = playerAdapter ?? MPMusicPlayerAdapter(defaultRate: rateManager.defaultRate)
         self.queue    = queueManager ?? MusicQueueManager()
@@ -70,7 +78,7 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             try session.setCategory(.playback, mode: .default)
             try session.setActive(true)
         } catch {
-            print("AVAudioSession error: \(error)")
+            logger.error("AVAudioSession error: \(error)")
         }
 
         timerCancellable = Timer.publish(every: 0.5, on: .main, in: .common)
@@ -124,6 +132,11 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
 
         if player.playbackState == .stopped {
             if repeatMode == .one, queue.currentSong != nil {
+                // 残高枯渇時はrepeat .oneの無限ループを抜けられないため、停止予約があればループ再生せず止める
+                if stopAtSongBoundaryIfNeeded(pausePlayer: false) {
+                    updateSnapshot()
+                    return
+                }
                 player.seek(to: 0)
                 player.play()
                 player.playbackRate = currentPlaybackRate
@@ -382,7 +395,7 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             let action = await queue.setQueue(newQueue, startAt: nextIndex)
             await handleQueueAction(action)
         } catch {
-            print("⚠️ Auto-play recommendation fetch error: \(error.localizedDescription)")
+            logger.error("Auto-play recommendation fetch error: \(error.localizedDescription)")
         }
     }
 
@@ -423,12 +436,18 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     private func updateSnapshot() {
         let item = player.nowPlayingItem
         let song = queue.currentSong
+        let timestamp = now()
+
+        allowanceEnforcer?.tick(
+            isPlaying: player.playbackState == .playing,
+            rate: currentPlaybackRate,
+            now: timestamp
+        )
+
         let title = song?.title ?? item?.title ?? "-"
         let artist = song?.artistName ?? item?.artist ?? "-"
         let duration = song?.duration ?? item?.playbackDuration ?? 0
         let currentTime = player.currentTime
-        let isPlaying = player.playbackState == .playing
-        let rate = currentPlaybackRate
 
         guard let song = song else {
             snapshot = MusicPlayerSnapshot.empty
@@ -437,6 +456,17 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
 
         let currentID = song.id.rawValue
         let isNewSong = (lastSnapshotSongID != currentID)
+
+        // MPMusicPlayerController.pause() の playbackState 反映は非同期のため、
+        // 停止ブロック内で明示的に書き換えられるよう先に読んでおく
+        var isPlaying = player.playbackState == .playing
+        let rate = currentPlaybackRate
+
+        // 残高枯渇時は現在の曲の末尾まで再生し、曲替わりのタイミングで停止する（ブツ切り防止）
+        if isNewSong, stopAtSongBoundaryIfNeeded(pausePlayer: true) {
+            isPlaying = false
+        }
+
         if isNewSong {
             lastSnapshotSongID = currentID
         }
@@ -459,7 +489,7 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
             do {
                 try historyManager.append(newSong)
             } catch {
-                print("⚠️ History append error: \(error.localizedDescription)")
+                logger.error("History append error: \(error.localizedDescription)")
             }
         }
         saveState()
@@ -467,14 +497,15 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         Task { [weak self] in
             guard let self = self else { return }
             let fetchedData = await self.artworkService.getArtwork(for: song)
+            // 取得完了時点のライブ値で再構築し、古い再生状態（rate/isPlaying）を再配信しない
             let updated = MusicPlayerSnapshot(
                 title: title,
                 artist: artist,
                 artworkData: fetchedData,
-                currentTime: currentTime,
+                currentTime: self.player.currentTime,
                 duration: duration,
-                rate: rate,
-                isPlaying: isPlaying
+                rate: self.currentPlaybackRate,
+                isPlaying: self.player.playbackState == .playing
             )
             self.snapshot = updated
         }
@@ -603,7 +634,7 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
                 try await player.prepareToPlay()
             } catch {
                 #if DEBUG
-                print("⚠️ prepareToPlay failed: \(error.localizedDescription)")
+                logger.error("prepareToPlay failed: \(error.localizedDescription)")
                 #endif
                 playbackErrorSubject.send(error)
                 return
@@ -620,6 +651,8 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     }
 
     private func restore() async {
+        // #69 で構造体化するまでの暫定
+        // swiftlint:disable:next large_tuple
         let st: (queueIDs: [String], currentIndex: Int, playbackRate: Double, shuffleModeRaw: Int, repeatModeRaw: Int, isAutoPlayEnabled: Bool)
         do {
             st = try persistenceService.loadState()
@@ -685,7 +718,21 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
                 isAutoPlayEnabled: isAutoPlayEnabled
             )
         } catch {
-            print("⚠️ State save error: \(error.localizedDescription)")
+            logger.error("State save error: \(error.localizedDescription)")
         }
+    }
+}
+
+private extension MusicPlayerServiceImpl {
+    /// 枯渇時は曲境界でのみ停止する。素の（等速）再生は制限しない
+    func stopAtSongBoundaryIfNeeded(pausePlayer: Bool) -> Bool {
+        guard let enforcer = allowanceEnforcer, enforcer.shouldStopAtSongBoundary() else { return false }
+        if pausePlayer {
+            player.pause()
+        }
+        currentPlaybackRate = Constants.MusicPlayer.normalPlaybackRate
+        player.playbackRate = currentPlaybackRate
+        enforcer.markStoppedAtSongEnd()
+        return true
     }
 }

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -7,7 +7,7 @@ import os
 
 @MainActor
 public final class MusicPlayerServiceImpl: MusicPlayerService {
-    private let logger = Logger(subsystem: "MizuRyu.Night-Core-Player", category: "MusicPlayer")
+    private let logger = Logger(subsystem: Constants.Logging.subsystem, category: "MusicPlayer")
     @Published public private(set) var snapshot: MusicPlayerSnapshot = .empty
     @Published public private(set) var isShuffled: Bool = false
     @Published public private(set) var repeatMode: Constants.RepeatMode = .none

--- a/Night-Core-PlayerTests/Mock/AllowanceServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/AllowanceServiceMock.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import Night_Core_Player
+
+@MainActor
+final class AllowanceServiceMock: AllowanceService {
+    var entitlementResult: PlaybackEntitlement = .free(remaining: Constants.Allowance.dailyFreeSeconds)
+
+    private(set) var consumeArgs: [(seconds: TimeInterval, now: Date)] = []
+
+    func entitlement(now: Date) throws -> PlaybackEntitlement {
+        entitlementResult
+    }
+
+    func consume(_ seconds: TimeInterval, now: Date) throws {
+        consumeArgs.append((seconds, now))
+    }
+
+    func grantReward(now: Date) throws -> TimeInterval { 0 }
+
+    func shouldShowProPrompt(now: Date) throws -> Bool { false }
+
+    func markProPromptShown(now: Date) throws {}
+}

--- a/Night-Core-PlayerTests/Services/AllowanceEnforcerTests.swift
+++ b/Night-Core-PlayerTests/Services/AllowanceEnforcerTests.swift
@@ -1,0 +1,199 @@
+import Testing
+import Foundation
+import Combine
+@testable import Night_Core_Player
+
+@Suite("AllowanceEnforcer Tests")
+@MainActor
+struct AllowanceEnforcerTests {
+
+    // MARK: - Helpers
+
+    private static let base = ISO8601DateFormatter().date(from: "2026-08-01T12:00:00+09:00")!
+
+    @MainActor
+    private final class EventRecorder {
+        var received: [AllowanceEvent] = []
+        private var cancellables: Set<AnyCancellable> = []
+
+        init(events: AnyPublisher<AllowanceEvent, Never>) {
+            events.sink { [weak self] in self?.received.append($0) }
+                .store(in: &cancellables)
+        }
+    }
+
+    private static func makeEnforcer(
+        entitlement: PlaybackEntitlement = .free(remaining: Constants.Allowance.dailyFreeSeconds)
+    ) -> (enforcer: AllowanceEnforcerImpl, mock: AllowanceServiceMock, recorder: EventRecorder) {
+        let mock = AllowanceServiceMock()
+        mock.entitlementResult = entitlement
+        let enforcer = AllowanceEnforcerImpl(allowanceService: mock)
+        let recorder = EventRecorder(events: enforcer.events)
+        return (enforcer, mock, recorder)
+    }
+
+    // MARK: - Tick / Consume
+
+    @Test("tick: 等速再生では消費しない")
+    func tickNormalRateDoesNotConsume() {
+        // Given: 残高ありのEnforcer
+        let (enforcer, mock, _) = Self.makeEnforcer()
+        let t0 = Self.base
+        // When: 等速で2回tick
+        enforcer.tick(isPlaying: true, rate: 1.0, now: t0)
+        enforcer.tick(isPlaying: true, rate: 1.0, now: t0.addingTimeInterval(10))
+        // Then: consumeは呼ばれない
+        #expect(mock.consumeArgs.isEmpty)
+    }
+
+    @Test("tick: 倍速+再生中は前回tickからの経過秒を消費する")
+    func tickNightcoreConsumesElapsedSeconds() {
+        // Given: 残高ありのEnforcer
+        let (enforcer, mock, _) = Self.makeEnforcer()
+        let t0 = Self.base
+        // When: 初回tick（計測起点）→ 10秒後にtick
+        enforcer.tick(isPlaying: true, rate: 1.5, now: t0)
+        enforcer.tick(isPlaying: true, rate: 1.5, now: t0.addingTimeInterval(10))
+        // Then: 2回目のtickで10秒消費。初回は起点のみで消費しない
+        #expect(mock.consumeArgs.count == 1)
+        #expect(mock.consumeArgs.first?.seconds == 10)
+    }
+
+    @Test("tick: 一時停止中は消費しない")
+    func tickPausedDoesNotConsume() {
+        let (enforcer, mock, _) = Self.makeEnforcer()
+        let t0 = Self.base
+        enforcer.tick(isPlaying: false, rate: 2.0, now: t0)
+        enforcer.tick(isPlaying: false, rate: 2.0, now: t0.addingTimeInterval(30))
+        #expect(mock.consumeArgs.isEmpty)
+    }
+
+    @Test("tick: 前回tickから60秒超の間隔は60秒にクランプされる")
+    func tickClampsLongGapToSixtySeconds() {
+        let (enforcer, mock, _) = Self.makeEnforcer()
+        let t0 = Self.base
+        // When: バックグラウンド放置を想定した1時間後のtick
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(3600))
+        // Then: 消費は60秒にクランプされる
+        #expect(mock.consumeArgs.count == 1)
+        #expect(mock.consumeArgs.first?.seconds == 60)
+    }
+
+    @Test("tick: トライアル中は枯渇扱いしない")
+    func tickTrialIsNotExhausted() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(
+            entitlement: .trial(endsAt: Self.base.addingTimeInterval(86400))
+        )
+        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        #expect(!enforcer.isExhausted)
+        #expect(recorder.received.isEmpty)
+    }
+
+    // MARK: - Exhaustion / Events
+
+    @Test("枯渇検知でexhaustedPendingSongEndを発行し、曲境界停止対象になる")
+    func exhaustionSetsBoundaryStop() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        // When: 枯渇状態でtick
+        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        // Then
+        #expect(enforcer.isExhausted)
+        #expect(enforcer.shouldStopAtSongBoundary())
+        #expect(recorder.received == [.exhaustedPendingSongEnd])
+    }
+
+    @Test("exhaustedPendingSongEndは二重発行されない")
+    func exhaustedEventFiresOnlyOnce() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        // When: 枯渇したまま複数回tick
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: false, rate: 1.0, now: t0.addingTimeInterval(20))
+        // Then: イベントは1回だけ
+        #expect(recorder.received == [.exhaustedPendingSongEnd])
+        #expect(enforcer.shouldStopAtSongBoundary())
+    }
+
+    @Test("残高回復するとshouldStopAtSongBoundaryがfalseに戻る")
+    func recoveryResetsBoundaryStop() {
+        let (enforcer, mock, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        // When: リワード広告等で残高が回復する
+        mock.entitlementResult = .free(remaining: Constants.Allowance.rewardSeconds)
+        enforcer.tick(isPlaying: false, rate: 1.0, now: t0.addingTimeInterval(10))
+        // Then: 停止対象が解除され、枯渇イベントは再発行されない
+        #expect(!enforcer.isExhausted)
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        #expect(recorder.received == [.exhaustedPendingSongEnd])
+    }
+
+    @Test("markStoppedAtSongEndで停止予約がクリアされる")
+    func markStoppedClearsPendingStop() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        #expect(enforcer.shouldStopAtSongBoundary())
+        // When: 曲境界での停止完了を通知
+        enforcer.markStoppedAtSongEnd()
+        // Then: 停止イベントが出て、停止予約は解除される
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        #expect(recorder.received == [.exhaustedPendingSongEnd, .stoppedAtSongEnd])
+    }
+
+    @Test("枯渇中でも等速ではアームされない（イベント発行なし）")
+    func exhaustionDoesNotArmAtNormalRate() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        // When: 枯渇したまま等速再生をtick
+        enforcer.tick(isPlaying: true, rate: 1.0, now: Self.base)
+        enforcer.tick(isPlaying: true, rate: 1.0, now: Self.base.addingTimeInterval(10))
+        // Then: 素のApple Music再生は止めないためアームしない
+        #expect(enforcer.isExhausted)
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        #expect(recorder.received.isEmpty)
+    }
+
+    @Test("枯渇後に等速へ戻ると停止予約が解除される")
+    func returningToNormalRateClearsPendingStop() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        #expect(enforcer.shouldStopAtSongBoundary())
+        // When: 倍速のまま枯渇検知後、ユーザーが等速へ戻して再生継続
+        enforcer.tick(isPlaying: true, rate: 1.0, now: t0.addingTimeInterval(10))
+        // Then: 停止予約のみ解除され、残高は枯渇したまま
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        #expect(enforcer.isExhausted)
+        #expect(recorder.received == [.exhaustedPendingSongEnd])
+    }
+
+    @Test("停止後に再度倍速へ上げると再アームされ、exhaustedPendingSongEndが2度目に発行される")
+    func rearmsWhenNightcoreResumesAfterStop() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        enforcer.markStoppedAtSongEnd()
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        // When: 手動で再度倍速へ上げて再生
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
+        // Then: 再アームされ、イベントは2回目に発行される
+        #expect(enforcer.shouldStopAtSongBoundary())
+        #expect(recorder.received == [
+            .exhaustedPendingSongEnd,
+            .stoppedAtSongEnd,
+            .exhaustedPendingSongEnd
+        ])
+    }
+
+    @Test("isExhaustedは残高状態を表し、停止予約とは独立している")
+    func isExhaustedIndependentFromPendingStop() {
+        let (enforcer, _, _) = Self.makeEnforcer(entitlement: .exhausted)
+        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        // When: 曲境界での停止を完了させる
+        enforcer.markStoppedAtSongEnd()
+        // Then: 残高は枯渇のまま、停止予約だけが解除される
+        #expect(enforcer.isExhausted)
+        #expect(!enforcer.shouldStopAtSongBoundary())
+    }
+}

--- a/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import SwiftUI
+import Combine
 import MediaPlayer
 import MusicKit
 
@@ -27,9 +28,10 @@ private struct SUT {
     let queueMock: QueueManagingMock
     let rateManager: PlaybackRateManagerImpl
     let repo: PlayerStateRepository
+    let allowanceEnforcer: AllowanceEnforcer?
 
     @MainActor
-    static func make() -> SUT {
+    static func make(allowanceEnforcer: AllowanceEnforcer? = nil) -> SUT {
         let adapter   = PlayerControllableMock()
         let queueMock = QueueManagingMock()
         let context = AppDataStore.shared.container.mainContext
@@ -47,10 +49,11 @@ private struct SUT {
             historyManager: historyManager,
             artworkService: artworkService,
             playerAdapter: adapter,
-            queueManager: queueMock
+            queueManager: queueMock,
+            allowanceEnforcer: allowanceEnforcer
         )
         return SUT(service: service, adapter: adapter, queueMock: queueMock,
-                   rateManager: rateManager, repo: repo)
+                   rateManager: rateManager, repo: repo, allowanceEnforcer: allowanceEnforcer)
     }
 }
 
@@ -963,5 +966,98 @@ struct CharacterizationTests {
         #expect(sut.adapter.playbackRate == 1.8, "adapter.playbackRate にも反映される")
         // VM の表示値も更新される
         #expect(settingsVM.defaultRate == 1.8, "settingsVM.defaultRate も同期される")
+    }
+}
+
+// MARK: - Allowance Enforcement（残高枯渇時の曲境界停止）
+@Suite("AllowanceEnforcement Tests", .serialized)
+@MainActor
+struct AllowanceEnforcementTests {
+
+    @Test("枯渇時: 曲境界で一時停止しレートが等速に戻り、イベントが順に発行される")
+    func exhaustStopsAtSongBoundary() async {
+        // Given: 残高ありの状態で2曲セットし、Aを自動再生
+        let mock = AllowanceServiceMock()
+        let enforcer = AllowanceEnforcerImpl(allowanceService: mock)
+        let sut = SUT.make(allowanceEnforcer: enforcer)
+
+        var receivedEvents: [AllowanceEvent] = []
+        var cancellables: Set<AnyCancellable> = []
+        enforcer.events.sink { receivedEvents.append($0) }
+            .store(in: &cancellables)
+
+        await sut.service.setQueue(
+            songs: [makeDummySong(id: "A"), makeDummySong(id: "B")],
+            startAt: 0
+        )
+        await sut.service.setSessionRate(2.0)
+        #expect(sut.service.snapshot.isPlaying == true, "Aが再生中")
+        #expect(receivedEvents.isEmpty, "残高がある間はイベントなし")
+
+        // When: 残高を枯渇させ、updateSnapshot 経由で tick を走らせる
+        mock.entitlementResult = .exhausted
+        await sut.service.seek(to: 10)
+        #expect(receivedEvents == [.exhaustedPendingSongEnd], "枯渇検知イベントが1回発行される")
+        #expect(sut.adapter.pauseCount == 0, "枯渇検知では即座には止めない")
+
+        // 次の曲へ進み、曲替わりを検知させる
+        await sut.service.next()
+        NotificationCenter.default.post(
+            name: .MPMusicPlayerControllerNowPlayingItemDidChange,
+            object: nil
+        )
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then: 曲境界で一時停止・レート等速に戻り、停止イベントが発行される
+        #expect(sut.service.nowPlayingIndex == 1)
+        #expect(sut.adapter.pauseCount == 1, "曲境界で pause する")
+        #expect(sut.adapter.playbackRate == Constants.MusicPlayer.normalPlaybackRate,
+                "player のレートが等速に戻る")
+        #expect(sut.service.snapshot.rate == Constants.MusicPlayer.normalPlaybackRate,
+                "session レートも等速に戻る")
+        #expect(sut.service.snapshot.isPlaying == false, "停止状態がスナップショットに反映される")
+        #expect(receivedEvents == [.exhaustedPendingSongEnd, .stoppedAtSongEnd])
+    }
+
+    @Test("枯渇後に等速で再開すると曲境界を跨いでも pause されない")
+    func resumeWithNormalRateDoesNotPauseAtNextBoundary() async {
+        // Given: 倍速で残高を枯渇させ、曲Bの頭で境界停止させておく
+        let mock = AllowanceServiceMock()
+        let enforcer = AllowanceEnforcerImpl(allowanceService: mock)
+        let sut = SUT.make(allowanceEnforcer: enforcer)
+
+        await sut.service.setQueue(
+            songs: [makeDummySong(id: "A"), makeDummySong(id: "B"), makeDummySong(id: "C")],
+            startAt: 0
+        )
+        await sut.service.setSessionRate(2.0)
+        mock.entitlementResult = .exhausted
+        await sut.service.seek(to: 10)
+
+        await sut.service.next()
+        NotificationCenter.default.post(
+            name: .MPMusicPlayerControllerNowPlayingItemDidChange,
+            object: nil
+        )
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(sut.service.nowPlayingIndex == 1)
+        #expect(sut.adapter.pauseCount == 1, "曲境界で一旦 pause する")
+
+        // When: 等速に戻して再開し、さらに次の曲へ送る
+        await sut.service.setSessionRate(Constants.MusicPlayer.normalPlaybackRate)
+        await sut.service.play()
+
+        await sut.service.next()
+        NotificationCenter.default.post(
+            name: .MPMusicPlayerControllerNowPlayingItemDidChange,
+            object: nil
+        )
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then: 等速再生のため残高枯渇中でも曲境界で pause しない
+        #expect(sut.service.nowPlayingIndex == 2)
+        #expect(sut.adapter.pauseCount == 1, "等速では枯渇していても pause されない")
+        #expect(sut.service.snapshot.isPlaying == true, "再生が継続している")
     }
 }


### PR DESCRIPTION
## 概要
AllowanceService（#60 / PR #80）を再生パイプラインへ配線。**PR #80 の上にスタック**（base = feature/60-time-balance。#80マージ後にbaseをmainへ変更）。

- `AllowanceEnforcer`（新規）: tick毎に倍速再生中のみ残高消費（60秒クランプ）。枯渇時は即停止せず**曲境界で停止予約**
- 状態機械: isBalanceExhausted（残高）と pendingStopAtSongEnd（停止予約）を分離。アームは「枯渇×再生中×倍速」のみ、クリアは「停止実行/残高回復/等速復帰」の3条件
- MusicPlayerServiceImpl: 曲境界停止を `stopAtSongBoundaryIfNeeded` に集約し、isNewSong検知と**repeat .one 分岐**の両方で判定（曲IDが変わらない抜け道を封鎖）
- events は AnyPublisher公開（外部からsend不可）。UI購読は #62/#65 で接続（TODO）
- enforcer未注入時は既存挙動と完全同一
- 付随: MusicPlayerServiceImpl の print×5 を os.Logger 化（lefthookの--strictゲートで既存warningがエラー化したため。触ったファイルはクリーンにする方針に従った）

## レビューサイクル
opencode(ox-alpha-free)実装 → **opus敵対的レビュー**（codexは認証失効のため代替）→ opencode修正 → Fable検証。
レビューで検出・修正済み:
- 【high】枯渇後は等速再生でも曲境界毎にpauseされ続ける（MusicKit規約違反経路）→ 状態機械分離
- 【high】repeat .one では曲境界が来ず残高0でも倍速無制限 → 分岐追加
- 【mid】pause()のplaybackState反映が非同期でsnapshotが再生中のまま → 明示代入
- 【mid】Date()直呼び → now: () -> Date 注入
- 【mid】PassthroughSubjectのprotocol公開でイベント偽装可能 → AnyPublisher化
- artwork非同期取得完了時に停止前の古いsnapshotを再配信する競合 → ライブ値で再構築

## 検証
- 全テストスイート green（新規: AllowanceEnforcerTests / MusicPlayerServiceTests追加。「枯渇→等速再開→曲境界複数回でpauseされない」を担保）
- 変更ファイル swiftlint --strict 0違反（lefthook通過）

closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)