### PR TITLE
feat: StoreKit 2でPro買い切りを実装 (#61)

### DIFF
--- a/Night-Core-Player.xcodeproj/project.pbxproj
+++ b/Night-Core-Player.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				NightCorePlayer.storekit,
 			);
 			target = F3FD9E842DCDAD7300645A6A /* Night-Core-Player */;
 		};

--- a/Night-Core-Player.xcodeproj/xcshareddata/xcschemes/Night-Core-Player.xcscheme
+++ b/Night-Core-Player.xcodeproj/xcshareddata/xcschemes/Night-Core-Player.xcscheme
@@ -63,6 +63,11 @@
             ReferencedContainer = "container:Night-Core-Player.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <Options>
+         <StoreKitConfigurationFileReference
+            identifier = "Night-Core-Player/NightCorePlayer.storekit">
+         </StoreKitConfigurationFileReference>
+      </Options>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Night-Core-Player/App.swift
+++ b/Night-Core-Player/App.swift
@@ -41,7 +41,11 @@ struct NightcorePlayerApp: App {
         let allowanceService = AllowanceServiceImpl(
             repo: AllowanceRepository(context: context)
         )
-        let allowanceEnforcer = AllowanceEnforcerImpl(allowanceService: allowanceService)
+        let proStoreService = ProStoreServiceImpl()
+        let allowanceEnforcer = AllowanceEnforcerImpl(
+            allowanceService: allowanceService,
+            isProEntitled: { proStoreService.isProEntitled }
+        )
 
         let service = MusicPlayerServiceImpl(
             rateManager: rateManager,
@@ -56,7 +60,8 @@ struct NightcorePlayerApp: App {
         _playerVM = State(initialValue: MusicPlayerViewModel(service: service))
         _settingsVM = State(initialValue: SettingsViewModel(
             rateManager: rateManager,
-            playerService: service
+            playerService: service,
+            proStore: proStoreService
         ))
         _searchVM = State(initialValue: SearchViewModel(musicKitService: musicKitService))
         _playlistVM = State(initialValue: PlaylistViewModel(musicKitService: musicKitService))

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -56,6 +56,8 @@ struct SettingsView: View {
                         .padding(.top, 8)
                 }
 
+                proSection
+
                 Section {
                     ForEach(OtherItem.allCases, id: \.self) { item in
                         VStack(spacing: 0) {
@@ -84,9 +86,109 @@ struct SettingsView: View {
                         .navigationBarTitleDisplayMode(.inline)
                 }
             }
+            .task {
+                await settingsVM.loadProState()
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .alert("Error", isPresented: Binding<Bool>(
+            get: { settingsVM.errorMessage != nil },
+            set: { if !$0 { settingsVM.errorMessage = nil } }
+        )) {
+            Button("OK") { settingsVM.errorMessage = nil }
+        } message: {
+            Text(settingsVM.errorMessage ?? "")
+        }
+        .alert("Pro", isPresented: Binding<Bool>(
+            get: { settingsVM.infoMessage != nil },
+            set: { if !$0 { settingsVM.infoMessage = nil } }
+        )) {
+            Button("OK") { settingsVM.infoMessage = nil }
+        } message: {
+            Text(settingsVM.infoMessage ?? "")
+        }
         .enableInjection()
+    }
+
+    // MARK: - Pro
+
+    @ViewBuilder
+    private var proSection: some View {
+        Section {
+            if settingsVM.isProEntitled {
+                HStack {
+                    Text("Pro Active")
+                        .font(.body)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Image(systemName: "checkmark.seal.fill")
+                        .foregroundColor(.green)
+                }
+                .padding(.vertical, 12)
+                .listRowSeparator(.hidden)
+            } else {
+                purchaseRow
+                restoreRow
+            }
+        } header: {
+            Text("Pro")
+                .font(.headline)
+                .foregroundColor(.primary)
+                .padding(.top, 8)
+        }
+    }
+
+    private var purchaseRow: some View {
+        VStack(spacing: 0) {
+            Button {
+                settingsVM.purchasePro()
+            } label: {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Unlock Pro")
+                            .font(.body)
+                            .foregroundColor(.primary)
+                        Text("Unlimited playback time")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    if settingsVM.isPurchasing {
+                        ProgressView()
+                    } else if let price = settingsVM.proPriceText {
+                        Text(price)
+                            .font(.body)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.primary)
+                    }
+                }
+                .padding(.vertical, 12)
+            }
+            .disabled(settingsVM.isPurchasing)
+            Divider()
+                .padding(.leading, 16)
+        }
+        .listRowSeparator(.hidden)
+    }
+
+    private var restoreRow: some View {
+        VStack(spacing: 0) {
+            Button {
+                settingsVM.restorePro()
+            } label: {
+                HStack {
+                    Text("Restore Purchases")
+                        .font(.body)
+                        .foregroundColor(.primary)
+                    Spacer()
+                }
+                .padding(.vertical, 12)
+            }
+            .disabled(settingsVM.isPurchasing)
+            Divider()
+                .padding(.leading, 16)
+        }
+        .listRowSeparator(.hidden)
     }
 
     @ViewBuilder

--- a/Night-Core-Player/Features/Settings/SettingsViewModel.swift
+++ b/Night-Core-Player/Features/Settings/SettingsViewModel.swift
@@ -1,18 +1,29 @@
 import SwiftUI
 import Observation
+import StoreKit
 
 @Observable
 @MainActor
 final class SettingsViewModel {
     var defaultRate: Double
     var errorMessage: String?
+    var infoMessage: String?
+    private(set) var isPurchasing = false
+    var isProEntitled: Bool { proStore?.isProEntitled ?? false }
+    private(set) var proPriceText: String?
 
     private let rateManager: PlaybackRateManager
     private let playerService: MusicPlayerService
+    private let proStore: ProStoreService?
 
-    init(rateManager: PlaybackRateManager, playerService: MusicPlayerService) {
+    init(
+        rateManager: PlaybackRateManager,
+        playerService: MusicPlayerService,
+        proStore: ProStoreService? = nil
+    ) {
         self.rateManager = rateManager
         self.playerService = playerService
+        self.proStore = proStore
         self.defaultRate = rateManager.defaultRate
     }
 
@@ -29,6 +40,49 @@ final class SettingsViewModel {
                 errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
             }
             await playerService.setSessionRate(clamped)
+        }
+    }
+
+    /// 表示価格とPro状態の取得。SettingsのProセクション表示時に呼ぶ
+    func loadProState() async {
+        guard let proStore else { return }
+        if proPriceText == nil {
+            proPriceText = await proStore.loadProduct()?.displayPrice
+        }
+    }
+
+    func purchasePro() {
+        Task {
+            guard !isPurchasing else { return }
+            guard let proStore else { return }
+            isPurchasing = true
+            defer { isPurchasing = false }
+            do {
+                switch try await proStore.purchase() {
+                case .pending:
+                    infoMessage = String(localized: "Purchase pending approval")
+                case .purchased, .cancelled:
+                    break
+                }
+            } catch {
+                errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
+            }
+            await loadProState()
+        }
+    }
+
+    func restorePro() {
+        Task {
+            guard !isPurchasing else { return }
+            guard let proStore else { return }
+            isPurchasing = true
+            defer { isPurchasing = false }
+            do {
+                try await proStore.restore()
+            } catch {
+                errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
+            }
+            await loadProState()
         }
     }
 }

--- a/Night-Core-Player/Localizable.xcstrings
+++ b/Night-Core-Player/Localizable.xcstrings
@@ -420,6 +420,76 @@
           }
         }
       }
+    },
+    "Pro": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro"
+          }
+        }
+      }
+    },
+    "Pro Active": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro 有効"
+          }
+        }
+      }
+    },
+    "Unlock Pro": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro を購入"
+          }
+        }
+      }
+    },
+    "Restore Purchases": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入を復元"
+          }
+        }
+      }
+    },
+    "Unlimited playback time": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再生時間の制限なし"
+          }
+        }
+      }
+    },
+    "Purchase pending approval": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入の承認待ちです"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Night-Core-Player/NightCorePlayer.storekit
+++ b/Night-Core-Player/NightCorePlayer.storekit
@@ -1,0 +1,43 @@
+{
+  "identifier" : "F36100000000000000000061",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "500",
+      "familyShareable" : false,
+      "internalID" : "6100000001",
+      "localizations" : [
+        {
+          "description" : "Unlock unlimited playback time.",
+          "displayName" : "Pro",
+          "locale" : "en_US"
+        },
+        {
+          "description" : "再生時間の制限を解除します。",
+          "displayName" : "Pro",
+          "locale" : "ja_JP"
+        }
+      ],
+      "productID" : "MizuRyu.Night-Core-Player.pro",
+      "referenceName" : "Pro",
+      "type" : "NonConsumable"
+    }
+  ],
+  "settings" : {
+    "_failTransactionsEnabled" : false,
+    "_locale" : "ja_JP",
+    "_storefront" : "JPN",
+    "_storeKitErrors" : [
+
+    ]
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/Night-Core-Player/Services/AllowanceEnforcer.swift
+++ b/Night-Core-Player/Services/AllowanceEnforcer.swift
@@ -32,6 +32,9 @@ final class AllowanceEnforcerImpl: AllowanceEnforcer {
 
     private let allowanceService: AllowanceService
 
+    /// Pro購入者は残高消費・枯渇停止の対象外。App.swiftでProStoreServiceに接続される
+    private let isProEntitled: () -> Bool
+
     private let eventSubject = PassthroughSubject<AllowanceEvent, Never>()
     var events: AnyPublisher<AllowanceEvent, Never> {
         eventSubject.eraseToAnyPublisher()
@@ -45,13 +48,26 @@ final class AllowanceEnforcerImpl: AllowanceEnforcer {
     /// 曲境界での停止予約。「枯滅+再生中+倍速」を観測したときだけアームされる
     private var pendingStopAtSongEnd = false
 
-    init(allowanceService: AllowanceService) {
+    init(
+        allowanceService: AllowanceService,
+        isProEntitled: @escaping () -> Bool = { false }
+    ) {
         self.allowanceService = allowanceService
+        self.isProEntitled = isProEntitled
     }
 
     var isExhausted: Bool { isBalanceExhausted }
 
     func tick(isPlaying: Bool, rate: Double, now: Date) {
+        // Proは消費もアームもしない。既存の停止予約があれば解除して即return
+        guard !isProEntitled() else {
+            // lastTickAtを進めないとPro期間ぶんが溜まり、Pro解除後の初回tickで一括消費される
+            lastTickAt = now
+            isBalanceExhausted = false
+            pendingStopAtSongEnd = false
+            return
+        }
+
         let baseline = lastTickAt ?? now
         lastTickAt = now
 
@@ -94,7 +110,8 @@ final class AllowanceEnforcerImpl: AllowanceEnforcer {
     }
 
     func shouldStopAtSongBoundary() -> Bool {
-        pendingStopAtSongEnd
+        // tickを経由せず曲境界判定が走っても、Proユーザーを止めない
+        !isProEntitled() && pendingStopAtSongEnd
     }
 
     func markStoppedAtSongEnd() {

--- a/Night-Core-Player/Services/ProStoreService.swift
+++ b/Night-Core-Player/Services/ProStoreService.swift
@@ -27,13 +27,14 @@ protocol ProStoreService: Sendable {
 @Observable
 @MainActor
 final class ProStoreServiceImpl: ProStoreService {
-    private let logger = Logger(subsystem: "MizuRyu.Night-Core-Player", category: "ProStore")
+    private let logger = Logger(subsystem: Constants.Logging.subsystem, category: "ProStore")
 
     static let productID = "MizuRyu.Night-Core-Player.pro"
 
     private(set) var isProEntitled = false
 
-    private var updatesTask: Task<Void, Never>?
+    // deinit(nonisolated)からcancelするため隔離を外す。書き込みはinitのみ
+    private nonisolated(unsafe) var updatesTask: Task<Void, Never>?
 
     /// 取得済みの商品。purchase()のたびの再取得を避ける
     private var cachedProduct: Product?

--- a/Night-Core-Player/Services/ProStoreService.swift
+++ b/Night-Core-Player/Services/ProStoreService.swift
@@ -1,0 +1,136 @@
+import Foundation
+import StoreKit
+import Observation
+import os
+
+// MARK: - Outcome
+
+/// purchase()の結果種別。キャンセルと承認待ちをBoolでは区別できないため分けている
+enum ProPurchaseOutcome {
+    case purchased
+    case cancelled
+    case pending
+}
+
+// MARK: - Protocol
+
+@MainActor
+protocol ProStoreService: Sendable {
+    var isProEntitled: Bool { get }
+    func loadProduct() async -> Product?
+    func purchase() async throws -> ProPurchaseOutcome
+    func restore() async throws
+}
+
+// MARK: - Impl
+
+@Observable
+@MainActor
+final class ProStoreServiceImpl: ProStoreService {
+    private let logger = Logger(subsystem: "MizuRyu.Night-Core-Player", category: "ProStore")
+
+    static let productID = "MizuRyu.Night-Core-Player.pro"
+
+    private(set) var isProEntitled = false
+
+    private var updatesTask: Task<Void, Never>?
+
+    /// 取得済みの商品。purchase()のたびの再取得を避ける
+    private var cachedProduct: Product?
+
+    init() {
+        updatesTask = Task { [weak self] in
+            await self?.observeTransactionUpdates()
+        }
+    }
+
+    deinit {
+        updatesTask?.cancel()
+    }
+
+    func loadProduct() async -> Product? {
+        do {
+            let products = try await Product.products(for: [Self.productID])
+            cachedProduct = products.first
+            return cachedProduct
+        } catch {
+            logger.error("Pro product load failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func purchase() async throws -> ProPurchaseOutcome {
+        let product: Product
+        if let cachedProduct {
+            product = cachedProduct
+        } else if let loaded = await loadProduct() {
+            product = loaded
+        } else {
+            logger.error("Pro product not found: \(Self.productID)")
+            return .cancelled
+        }
+        let result = try await product.purchase()
+        switch result {
+        case .success(let verification):
+            // 検証失敗時はfinishせずエラーとして返す（不正トランザクションを完了扱いにしない）
+            let transaction = try Self.checkVerified(verification)
+            await refreshEntitlement()
+            await transaction.finish()
+            logger.info("Pro purchased (transaction id: \(transaction.id))")
+            return .purchased
+        case .userCancelled:
+            return .cancelled
+        case .pending:
+            logger.info("Pro purchase pending approval")
+            return .pending
+        @unknown default:
+            logger.error("Unknown purchase result")
+            return .cancelled
+        }
+    }
+
+    func restore() async throws {
+        try await AppStore.sync()
+        await refreshEntitlement()
+        logger.info("Pro entitlements refreshed after restore (entitled: \(self.isProEntitled))")
+    }
+
+    // MARK: - Private
+
+    private func observeTransactionUpdates() async {
+        // 起動直後の権限状態を先に同期してから更新監視に入る
+        await refreshEntitlement()
+        for await update in Transaction.updates {
+            do {
+                let transaction = try Self.checkVerified(update)
+                await refreshEntitlement()
+                await transaction.finish()
+                logger.info("Transaction update processed (transaction id: \(transaction.id))")
+            } catch {
+                // 検証失敗トランザクションは finish しない方針のため Transaction.updates に再配信され続ける
+                logger.fault("Transaction update verification failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func refreshEntitlement() async {
+        var entitled = false
+        for await entitlement in Transaction.currentEntitlements {
+            guard let transaction = try? Self.checkVerified(entitlement) else { continue }
+            if transaction.productID == Self.productID, transaction.revocationDate == nil {
+                entitled = true
+                break
+            }
+        }
+        isProEntitled = entitled
+    }
+
+    private nonisolated static func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified(_, let error):
+            throw error
+        case .verified(let safe):
+            return safe
+        }
+    }
+}

--- a/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
@@ -196,4 +196,3 @@ struct SettingsViewModelTests {
         #expect(vm.infoMessage == nil)
     }
 }
-}

--- a/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
@@ -13,6 +13,8 @@ final class PlaybackRateManagerMock: PlaybackRateManager {
     }
 }
 
+private struct PurchaseTestError: Error {}
+
 // MARK: - Tests
 
 @Suite("SettingsViewModel Tests", .serialized)
@@ -33,7 +35,7 @@ struct SettingsViewModelTests {
         }
     }
 
-    private static func setUp() -> (
+    private static func setUp(proStore: ProStoreService? = nil) -> (
         vm: SettingsViewModel,
         rateMock: PlaybackRateManagerMock,
         svcMock: MusicPlayerServiceMock
@@ -42,7 +44,8 @@ struct SettingsViewModelTests {
         let svcMock = MusicPlayerServiceMock()
         let vm = SettingsViewModel(
             rateManager: rateMock,
-            playerService: svcMock
+            playerService: svcMock,
+            proStore: proStore
         )
         return (vm, rateMock, svcMock)
     }
@@ -116,7 +119,81 @@ struct SettingsViewModelTests {
 
         // Then
         #expect(vm.defaultRate == minRate, "ViewModelのdefaultRateがminにクランプ")
-        #expect(rateMock.setDefaultRateArgs.first == minRate, "rateManagerにmin値が渡される")
-        #expect(svcMock.rateArgs.first == minRate, "playerServiceにmin値が渡される")
+        #expect(rateMock.setDefaultRateArgs.first == minRate, "rateManagerにクランプ後の値が渡される")
+        #expect(svcMock.rateArgs.first == minRate, "playerServiceにクランプ後の値が渡される")
     }
+
+    // MARK: - Pro Store
+
+    @Test("purchasePro: purchase()がthrowしたらerrorMessageが設定されること")
+    func purchasePro_purchaseThrows_setsErrorMessage() async throws {
+        // Given
+        let storeMock = ProStoreServiceMock()
+        storeMock.purchaseResult = .failure(PurchaseTestError())
+        let (vm, _, _) = SettingsViewModelTests.setUp(proStore: storeMock)
+
+        // When
+        vm.purchasePro()
+        await SettingsViewModelTests.waitUntil { vm.errorMessage != nil }
+
+        // Then
+        #expect(vm.errorMessage != nil, "エラーメッセージが設定される")
+        #expect(vm.infoMessage == nil, "情報メッセージは設定されない")
+    }
+
+    @Test("purchasePro: 購入成功後にisProEntitledがtrueになること")
+    func purchasePro_purchaseSucceeds_entitlesPro() async throws {
+        // Given
+        let storeMock = ProStoreServiceMock()
+        storeMock.purchaseResult = .success(.purchased)
+        storeMock.entitledResult = true
+        let (vm, _, _) = SettingsViewModelTests.setUp(proStore: storeMock)
+
+        // When
+        vm.purchasePro()
+        await SettingsViewModelTests.waitUntil { vm.isProEntitled }
+
+        // Then
+        #expect(vm.isProEntitled, "購入成功後にPro権限が有効になる")
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("purchasePro: isPurchasing中の再呼び出しはpurchase()を実行しないこと")
+    func purchasePro_whilePurchasing_skipsSecondCall() async throws {
+        // Given: purchase()を遅延させ、処理中の窓を作る
+        let storeMock = ProStoreServiceMock()
+        storeMock.purchaseResult = .success(.purchased)
+        storeMock.entitledResult = true
+        storeMock.purchaseDelayMilliseconds = 500
+        let (vm, _, _) = SettingsViewModelTests.setUp(proStore: storeMock)
+
+        // When: 1回目を実行し、処理中に2回目を呼ぶ
+        vm.purchasePro()
+        await SettingsViewModelTests.waitUntil { vm.isPurchasing }
+        let countDuringFirst = storeMock.purchaseCallCount
+        vm.purchasePro()
+
+        // Then: 2回目は無視され、purchase()は1回だけ実行される
+        #expect(storeMock.purchaseCallCount == countDuringFirst, "処理中の再呼び出しでpurchase()が増えない")
+        await SettingsViewModelTests.waitUntil { !vm.isPurchasing }
+        #expect(storeMock.purchaseCallCount == 1, "purchase()は1回だけ実行される")
+    }
+
+    @Test("proStoreなし: loadProState()/purchasePro()が無害に終了すること")
+    func withoutProStore_callsAreHarmless() async throws {
+        // Given
+        let (vm, _, _) = SettingsViewModelTests.setUp()
+
+        // When
+        await vm.loadProState()
+        vm.purchasePro()
+
+        // Then: エラー・情報・状態変化は起きない
+        await SettingsViewModelTests.waitUntil { !vm.isPurchasing }
+        #expect(!vm.isProEntitled, "Pro権限は無効のまま")
+        #expect(vm.proPriceText == nil, "価格は読み込まれない")
+        #expect(vm.errorMessage == nil)
+        #expect(vm.infoMessage == nil)
+    }
+}
 }

--- a/Night-Core-PlayerTests/Mock/ProStoreServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/ProStoreServiceMock.swift
@@ -1,0 +1,39 @@
+import Foundation
+import StoreKit
+@testable import Night_Core_Player
+
+@MainActor
+final class ProStoreServiceMock: ProStoreService {
+    var entitledResult = false
+    var productResult: Product?
+    var purchaseResult: Result<ProPurchaseOutcome, Error> = .success(.cancelled)
+    var restoreError: Error?
+    /// purchase()を指定ミリ秒だけ遅らせ、isPurchasing中の再入テスト用に使う
+    var purchaseDelayMilliseconds: Int = 0
+
+    private(set) var loadProductCallCount = 0
+    private(set) var purchaseCallCount = 0
+    private(set) var restoreCallCount = 0
+
+    var isProEntitled: Bool { entitledResult }
+
+    func loadProduct() async -> Product? {
+        loadProductCallCount += 1
+        return productResult
+    }
+
+    func purchase() async throws -> ProPurchaseOutcome {
+        purchaseCallCount += 1
+        if purchaseDelayMilliseconds > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(purchaseDelayMilliseconds) * 1_000_000)
+        }
+        return try purchaseResult.get()
+    }
+
+    func restore() async throws {
+        restoreCallCount += 1
+        if let restoreError {
+            throw restoreError
+        }
+    }
+}

--- a/Night-Core-PlayerTests/Services/AllowanceEnforcerTests.swift
+++ b/Night-Core-PlayerTests/Services/AllowanceEnforcerTests.swift
@@ -23,11 +23,15 @@ struct AllowanceEnforcerTests {
     }
 
     private static func makeEnforcer(
-        entitlement: PlaybackEntitlement = .free(remaining: Constants.Allowance.dailyFreeSeconds)
+        entitlement: PlaybackEntitlement = .free(remaining: Constants.Allowance.dailyFreeSeconds),
+        isProEntitled: @escaping () -> Bool = { false }
     ) -> (enforcer: AllowanceEnforcerImpl, mock: AllowanceServiceMock, recorder: EventRecorder) {
         let mock = AllowanceServiceMock()
         mock.entitlementResult = entitlement
-        let enforcer = AllowanceEnforcerImpl(allowanceService: mock)
+        let enforcer = AllowanceEnforcerImpl(
+            allowanceService: mock,
+            isProEntitled: isProEntitled
+        )
         let recorder = EventRecorder(events: enforcer.events)
         return (enforcer, mock, recorder)
     }
@@ -88,6 +92,47 @@ struct AllowanceEnforcerTests {
         enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
         #expect(!enforcer.isExhausted)
         #expect(recorder.received.isEmpty)
+    }
+
+    @Test("Pro有効時はtickで消費されずアームもされない")
+    func tickWithProDoesNotConsumeOrArm() {
+        // Given: 残高枯渇だがPro有効
+        let isPro = true
+        let (enforcer, mock, recorder) = Self.makeEnforcer(
+            entitlement: .exhausted,
+            isProEntitled: { isPro }
+        )
+        let t0 = Self.base
+        // When: 倍速+再生中で複数回tick
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
+        // Then: 消費も停止予約のアームも行わない
+        #expect(mock.consumeArgs.isEmpty)
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        #expect(recorder.received.isEmpty)
+    }
+
+    @Test("Pro有効化で既存の停止予約がクリアされる")
+    func proActivationClearsPendingStop() {
+        // Given: 枯渇+倍速の非Pro状態。2回目のtickで経過秒が消費され、アーム済みになる
+        var isPro = false
+        let (enforcer, mock, recorder) = Self.makeEnforcer(
+            entitlement: .exhausted,
+            isProEntitled: { isPro }
+        )
+        let t0 = Self.base
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
+        #expect(enforcer.shouldStopAtSongBoundary())
+        #expect(mock.consumeArgs.first?.seconds == 10)
+        let consumeCountBeforePro = mock.consumeArgs.count
+        // When: Proを購入して有効化
+        isPro = true
+        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(20))
+        // Then: 停止予約が解除され、Pro化後のtickでは消費も再アームもされない
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        #expect(mock.consumeArgs.count == consumeCountBeforePro)
+        #expect(recorder.received == [.exhaustedPendingSongEnd])
     }
 
     // MARK: - Exhaustion / Events


### PR DESCRIPTION
## 概要
Pro買い切り（非消耗型 `MizuRyu.Night-Core-Player.pro`）をStoreKit 2で実装。

- `ProStoreService`（新規・@Observable）: Transaction.currentEntitlements走査でPro判定、Transaction.updates監視で購入・返金を反映。verifiedのみfinish（検証失敗はfinishせず再配信される旨コメント明記）
- `AllowanceEnforcer`接続: Pro時はtickで消費・アームせず、`shouldStopAtSongBoundary()`もPro時は常にfalse（tick未経由でも止めない）
- Settings UI: Proセクション（購入・復元を**別々の行**に分離）、多重タップ防止（isPurchasing＋ProgressView）、`.pending`（承認待ち）の情報表示
- `NightCorePlayer.storekit`（ローカルテスト用設定、schemeに接続済み）＋ ja/en文言追加

## レビューサイクル
opencode実装 → opus敵対的レビュー（high1・mid7・low8）→ opencode修正 → Fable検証。
主な修正: List行内2ボタンの同時発火（SwiftUI既知挙動）／Pro解除後の初回tickで最大60秒一括消費／.pendingが無反応／Settings表示中のentitlement変化が未反映（@Observable化）／purchase()の商品再取得

## 検証
- 全テストスイート green（新規: SettingsViewModelTests 4本、AllowanceEnforcerTests Pro系2本）
- 変更ファイル swiftlint --strict 0違反

## マージ後のユーザー作業（App Store Connect）
- [ ] Paid Applications Agreement 同意
- [ ] IAP商品登録: ID `MizuRyu.Night-Core-Player.pro`（**登録前にハイフン可否を要確認**。作成後は変更不可）、価格 ¥500 tier
- [ ] 小規模事業者プログラム（手数料15%）の申請状況確認

closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## キャプチャ

| 設定画面のProセクション |
|---|
| <img src="https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-83/settings-pro.png?raw=true" width="320" /> |

購入フローの動画デモは #84（デモ録画基盤）マージ後に追加予定。
