### PR TITLE
feat: pr-assets運用とE2Eデモ録画基盤 (#84)

### DIFF
--- a/.github/workflows/demo-catalog.yml
+++ b/.github/workflows/demo-catalog.yml
@@ -1,0 +1,154 @@
+# PR が merge されたとき、pr-assets ブランチの pr-<番号>/manifest.json を読んで
+# features/<機能>/ を「その機能の最新デモ」に更新し、索引 features/README.md を再生成する
+# （docs/conventions/pr-assets.md「機能カタログ」）。
+#
+# 動画を添付する PR は少数なので、manifest が無ければ何もせず成功する（通常経路）。
+# pr-<番号>/ は読むだけで動かさない（過去 PR 本文のリンクが張られているため）。
+name: demo-catalog
+
+on:
+  pull_request:
+    types: [closed]
+  # 過去 PR の取り込み直し（backfill）・障害時の再実行用。
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "カタログへ反映する PR 番号"
+        required: true
+        type: string
+
+# Why not: concurrency で直列化しない。GitHub の concurrency group は「実行中1件＋待機1件」しか
+# 保持せず、3件以上が同時に merge されると待機中の run がキャンセルされ、その PR の昇格が永久に
+# 失われる。全 run を走らせ、push 競合は下のリトライ（fetch → reset → 再生成）で吸収する。
+
+# pr-assets ブランチへの push にだけ書き込みが要る。
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    name: promote demo to catalog
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+
+    steps:
+      # 索引生成スクリプト（main 側）。pr-assets の中身はここには入らない。
+      # persist-credentials: false — このジョブはリポジトリへの書き込みトークンを持つ唯一の
+      # ジョブなので、スクリプトを走らせる作業ツリーには認証情報を残さない。
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      # Why not: pnpm install しない。書き込みトークンを持つジョブで依存の lifecycle script を
+      # 走らせないため。build-demo-catalog.ts は node 標準 API だけで書かれており、
+      # Node 24 の型ストリップで .ts を直接実行できる（実測済み）。
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          # setup-node v5 は package-manager-cache が既定で有効で、package.json の
+          # packageManager（pnpm）を見てキャッシュを設定しようとする。このジョブは
+          # 上記のとおり pnpm を入れないため、切っておかないと pnpm を探して落ちる。
+          package-manager-cache: false
+
+      # workflow_dispatch の input は任意の文字列を渡せるため、シェルへ ${{ }} で
+      # 展開せず env 経由で受けて数値であることを検証する（コマンド注入の遮断）。
+      - name: Resolve PR number
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr-number }}
+          MERGED_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            number="$DISPATCH_PR_NUMBER"
+          else
+            number="$MERGED_PR_NUMBER"
+          fi
+          case "$number" in
+            '' | *[!0-9]*)
+              echo "PR 番号が数値ではない: $number" >&2
+              exit 1
+              ;;
+          esac
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      # pr-assets はまだ作られていない可能性がある（初回運用時）。その場合は何もせず成功する。
+      # API 呼び出し自体の失敗ではステップごと落とす（通信・権限の異常を「ブランチが無い」に
+      # 丸めると、昇格が黙って飛ぶ）。
+      - name: Check pr-assets branch exists
+        id: assets-branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branches=$(gh api "repos/${GITHUB_REPOSITORY}/branches" --paginate --jq '.[].name')
+          if printf '%s\n' "$branches" | grep -qx 'pr-assets'; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr-assets ブランチが無いため何もしない"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # orphan ブランチなので ref 指定で別ディレクトリへ取る。fetch-depth は 1:
+      # 動画の履歴を全部引くと重く、コミットして push するだけなら最新1つで足りる。
+      # push するのはこの作業ツリーだけなので、認証情報はここにだけ残す（fork PR では
+      # token が read-only になり push は失敗する。private リポジトリで fork 運用は無い前提）。
+      - name: Checkout pr-assets branch
+        if: steps.assets-branch.outputs.exists == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: pr-assets
+          path: pr-assets
+          fetch-depth: 1
+          persist-credentials: true
+
+      # 生成 → commit → push を1ステップに閉じる。push が競合で弾かれたら origin を取り込み
+      # 直して同じ手順をやり直す（生成は冪等なので繰り返せる）。
+      - name: Update catalog and push
+        if: steps.assets-branch.outputs.exists == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          ASSETS_DIR: ${{ github.workspace }}/pr-assets
+        run: |
+          set -euo pipefail
+          git -C "$ASSETS_DIR" config user.name "github-actions[bot]"
+          git -C "$ASSETS_DIR" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          push_log="$(mktemp)"
+          for attempt in 1 2 3; do
+            node scripts/build-demo-catalog.ts --assets-dir "$ASSETS_DIR" --pr "$PR_NUMBER"
+
+            if [ ! -d "$ASSETS_DIR/features" ]; then
+              echo "features/ が無い（この PR にデモは無い）ため push しない"
+              exit 0
+            fi
+
+            # features/ 以外は絶対にコミットしない。人が書くルート README と
+            # pr-<番号>/（過去 PR の証跡）を、生成側の不具合から守る最後の防壁。
+            git -C "$ASSETS_DIR" add -A -- features/
+            if git -C "$ASSETS_DIR" diff --cached --quiet; then
+              echo "カタログに差分が無いため push しない"
+              exit 0
+            fi
+
+            git -C "$ASSETS_DIR" commit -m "chore(demo-catalog): PR #${PR_NUMBER} のデモを features/ へ反映"
+            if git -C "$ASSETS_DIR" push origin HEAD:pr-assets 2>&1 | tee "$push_log"; then
+              exit 0
+            fi
+
+            # 競合（先に誰かが push した）以外は繰り返しても直らないので、そのまま失敗させる。
+            if ! grep -qE 'non-fast-forward|fetch first|\[rejected\]' "$push_log"; then
+              echo "競合以外の理由で push に失敗した。リトライしない" >&2
+              exit 1
+            fi
+            # 最終試行では reset しない（失敗時のコミットを残して調査できるようにする）。
+            if [ "$attempt" -eq 3 ]; then
+              echo "push を 3 回試みたが競合が解消しなかった" >&2
+              exit 1
+            fi
+
+            echo "push が競合で弾かれた（${attempt} 回目）。origin/pr-assets を取り込んでやり直す" >&2
+            git -C "$ASSETS_DIR" fetch --depth=1 origin pr-assets
+            git -C "$ASSETS_DIR" reset --hard FETCH_HEAD
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ docs/memo/
 docs/assets/
 privacy-policy/site/
 .claude/plans/
+demo-output/

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,12 @@ lint: ## SwiftLint で全体を検査（警告は失敗にしない。--strict �
 swiftformat-lint: ## SwiftFormat の整形漏れを検査（修正はしない）
 	swiftformat --lint .
 
-test: ## ユニットテスト実行
+test: ## ユニットテスト実行（デモ用UIテストは除外。実行は scripts/record-demo.sh）
 	xcodebuild test \
 		-project $(PROJECT) \
 		-scheme $(SCHEME) \
 		-destination '$(DESTINATION)' \
+		-skip-testing:Night-Core-PlayerUITests \
 		-parallel-testing-enabled NO \
 		-quiet
 

--- a/Night-Core-Player.xcodeproj/project.pbxproj
+++ b/Night-Core-Player.xcodeproj/project.pbxproj
@@ -7,10 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A5134877AEF6FB940CE1BAA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E84CD932BDCBA06A22132B14 /* Foundation.framework */; };
+		E1A1957EC4B920C2CEC656A3 /* DemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE74BD8A1D03DB172F3F71C /* DemoUITests.swift */; };
 		F391D4232DCF2E5500517D0B /* Inject in Frameworks */ = {isa = PBXBuildFile; productRef = F391D4222DCF2E5500517D0B /* Inject */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		A7A6251639AAE61EC477BF4E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F3FD9E7D2DCDAD7300645A6A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F3FD9E842DCDAD7300645A6A;
+			remoteInfo = "Night-Core-Player";
+		};
 		F36015E02DD6E8EE008A255A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F3FD9E7D2DCDAD7300645A6A /* Project object */;
@@ -21,6 +30,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2BB8A8A07086B6F764DB8B31 /* Night-Core-PlayerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Night-Core-PlayerUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BE74BD8A1D03DB172F3F71C /* DemoUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoUITests.swift; sourceTree = "<group>"; };
+		E84CD932BDCBA06A22132B14 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		F36015DC2DD6E8EE008A255A /* Night-Core-PlayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Night-Core-PlayerTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3FD9E852DCDAD7300645A6A /* Night-Core-Player.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Night-Core-Player.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -38,6 +50,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		F36015DD2DD6E8EE008A255A /* Night-Core-PlayerTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = "Night-Core-PlayerTests";
 			sourceTree = "<group>";
 		};
@@ -52,6 +66,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		B51E75C58B2D8BAB7D7C6AAF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A5134877AEF6FB940CE1BAA /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F36015D92DD6E8EE008A255A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -70,12 +92,39 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2890C6E38775A9310CD17A46 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B0A9F31170DBC1BA5A4E0749 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4C29488CDB7791492A1D9FDB /* Night-Core-PlayerUITests */ = {
+			isa = PBXGroup;
+			children = (
+				5BE74BD8A1D03DB172F3F71C /* DemoUITests.swift */,
+			);
+			name = "Night-Core-PlayerUITests";
+			path = "Night-Core-PlayerUITests";
+			sourceTree = "<group>";
+		};
+		B0A9F31170DBC1BA5A4E0749 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				E84CD932BDCBA06A22132B14 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		F3FD9E7C2DCDAD7300645A6A = {
 			isa = PBXGroup;
 			children = (
 				F3FD9E872DCDAD7300645A6A /* Night-Core-Player */,
 				F36015DD2DD6E8EE008A255A /* Night-Core-PlayerTests */,
 				F3FD9E862DCDAD7300645A6A /* Products */,
+				2890C6E38775A9310CD17A46 /* Frameworks */,
+				4C29488CDB7791492A1D9FDB /* Night-Core-PlayerUITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -84,6 +133,7 @@
 			children = (
 				F3FD9E852DCDAD7300645A6A /* Night-Core-Player.app */,
 				F36015DC2DD6E8EE008A255A /* Night-Core-PlayerTests.xctest */,
+				2BB8A8A07086B6F764DB8B31 /* Night-Core-PlayerUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -91,6 +141,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		C64BF47F7AAB1B2C09CEC5D0 /* Night-Core-PlayerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 14C847AD4F1C726B67FA7094 /* Build configuration list for PBXNativeTarget "Night-Core-PlayerUITests" */;
+			buildPhases = (
+				8BD7D98FBA01C751B111D235 /* Sources */,
+				B51E75C58B2D8BAB7D7C6AAF /* Frameworks */,
+				55D815E4C0B9CCAFA7C3B4A2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A5621167491B67F060FABD02 /* PBXTargetDependency */,
+			);
+			name = "Night-Core-PlayerUITests";
+			productName = "Night-Core-PlayerUITests";
+			productReference = 2BB8A8A07086B6F764DB8B31 /* Night-Core-PlayerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		F36015DB2DD6E8EE008A255A /* Night-Core-PlayerTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F36015E22DD6E8EE008A255A /* Build configuration list for PBXNativeTarget "Night-Core-PlayerTests" */;
@@ -108,8 +176,6 @@
 				F36015DD2DD6E8EE008A255A /* Night-Core-PlayerTests */,
 			);
 			name = "Night-Core-PlayerTests";
-			packageProductDependencies = (
-			);
 			productName = "Night-Core-PlayerTests";
 			productReference = F36015DC2DD6E8EE008A255A /* Night-Core-PlayerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -176,11 +242,19 @@
 			targets = (
 				F3FD9E842DCDAD7300645A6A /* Night-Core-Player */,
 				F36015DB2DD6E8EE008A255A /* Night-Core-PlayerTests */,
+				C64BF47F7AAB1B2C09CEC5D0 /* Night-Core-PlayerUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		55D815E4C0B9CCAFA7C3B4A2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F36015DA2DD6E8EE008A255A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -198,6 +272,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		8BD7D98FBA01C751B111D235 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1A1957EC4B920C2CEC656A3 /* DemoUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F36015D82DD6E8EE008A255A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -215,6 +297,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		A5621167491B67F060FABD02 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Night-Core-Player";
+			target = F3FD9E842DCDAD7300645A6A /* Night-Core-Player */;
+			targetProxy = A7A6251639AAE61EC477BF4E /* PBXContainerItemProxy */;
+		};
 		F36015E12DD6E8EE008A255A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F3FD9E842DCDAD7300645A6A /* Night-Core-Player */;
@@ -223,6 +311,37 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		08D52B7A317FAFBB317A23FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "MizuRyu.Night-Core-PlayerUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = "Night-Core-Player";
+			};
+			name = Debug;
+		};
+		20B1BB68C821A2DF0A5CC6E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "MizuRyu.Night-Core-PlayerUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = "Night-Core-Player";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		F36015E32DD6E8EE008A255A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -451,6 +570,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		14C847AD4F1C726B67FA7094 /* Build configuration list for PBXNativeTarget "Night-Core-PlayerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				20B1BB68C821A2DF0A5CC6E4 /* Release */,
+				08D52B7A317FAFBB317A23FB /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F36015E22DD6E8EE008A255A /* Build configuration list for PBXNativeTarget "Night-Core-PlayerTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Night-Core-Player.xcodeproj/xcshareddata/xcschemes/Night-Core-Player.xcscheme
+++ b/Night-Core-Player.xcodeproj/xcshareddata/xcschemes/Night-Core-Player.xcscheme
@@ -41,6 +41,16 @@
                ReferencedContainer = "container:Night-Core-Player.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C64BF47F7AAB1B2C09CEC5D0"
+               BuildableName = "Night-Core-PlayerUITests.xctest"
+               BlueprintName = "Night-Core-PlayerUITests"
+               ReferencedContainer = "container:Night-Core-Player.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Night-Core-Player/App.swift
+++ b/Night-Core-Player/App.swift
@@ -24,7 +24,14 @@ struct NightcorePlayerApp: App {
             #endif
         #endif
 
-        let musicKitService = MusicKitServiceImpl()
+        // シミュレータは FairPlay 非対応のため、-DEMO 時のみ MusicKit カタログ系をスタブへ差し替える
+        // （ensureAuth を no-op にすることで MusicAuthorization.request() も迂回する）
+        let musicKitService: any MusicKitService
+        if ProcessInfo.processInfo.arguments.contains("-DEMO") {
+            musicKitService = DemoMusicKitService()
+        } else {
+            musicKitService = MusicKitServiceImpl()
+        }
 
         let context = AppDataStore.shared.container.mainContext
         let playerStateRepo = PlayerStateRepository(context: context)

--- a/Night-Core-Player/Features/Common/MiniMusicPlayerView.swift
+++ b/Night-Core-Player/Features/Common/MiniMusicPlayerView.swift
@@ -59,6 +59,7 @@ struct MiniMusicPlayerView: View {
             .padding(.trailing, 8)
         }
         .frame(maxWidth: .infinity)
+        .accessibilityIdentifier("mini_player")
         .enableInjection()
     }
 }

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -145,13 +145,14 @@ struct MusicPlayerView: View {
                             .font(.title2)
                             .foregroundColor(.indigo)
                     }
-                    Button(action: {
+                    Button {
                         vm.playPauseTrack()
-                    }) {
+                    } label: {
                         Image(systemName: vm.isPlaying ? "pause.fill" : "play.fill")
                             .font(.largeTitle)
                             .foregroundColor(.indigo)
                     }
+                    .accessibilityIdentifier("player_play_pause")
                     Button { vm.forward15() } label: {
                         Image(systemName: "goforward.15")
                             .font(.title2)
@@ -182,20 +183,25 @@ struct MusicPlayerView: View {
                         SpeedControlButton(label: "-\(Constants.MusicPlayer.rateStepLarge)", color: .red) {
                             vm.adjustRate(by: -Constants.MusicPlayer.rateStepLarge)
                         }
+                        .accessibilityIdentifier("speed_decrease_large")
                         SpeedControlButton(label: "-\(Constants.MusicPlayer.rateStepSmall)", color: .red) {
                             vm.adjustRate(by: -Constants.MusicPlayer.rateStepSmall)
                         }
+                        .accessibilityIdentifier("speed_decrease_small")
                         Text(String(format: "%.2fx", vm.rate))
                             .font(.callout)
                             .foregroundColor(.secondary)
                             .padding(.horizontal, 8)
                             .frame(minWidth: 40)
+                            .accessibilityIdentifier("playback_rate_label")
                         SpeedControlButton(label: "+\(Constants.MusicPlayer.rateStepSmall)", color: .green) {
                             vm.adjustRate(by: Constants.MusicPlayer.rateStepSmall)
                         }
+                        .accessibilityIdentifier("speed_increase_small")
                         SpeedControlButton(label: "+\(Constants.MusicPlayer.rateStepLarge)", color: .green) {
                             vm.adjustRate(by: Constants.MusicPlayer.rateStepLarge)
                         }
+                        .accessibilityIdentifier("speed_increase_large")
                     }
                 }
 

--- a/Night-Core-Player/Features/Search/SearchView.swift
+++ b/Night-Core-Player/Features/Search/SearchView.swift
@@ -59,6 +59,7 @@ struct SearchView: View {
                         .textInputAutocapitalization(.never)
                         .disableAutocorrection(true)
                         .submitLabel(.search)
+                        .accessibilityIdentifier("search_field")
                     Spacer()
                     Image(systemName: "mic.fill")
                 }
@@ -96,6 +97,7 @@ struct SearchView: View {
                             } label: {
                                 SearchRowView(song: song)
                             }
+                            .accessibilityIdentifier("search_result_song")
                             .onAppear {
                                 Task { await vm.loadMoreSongsIfNeeded(currentSong: song) }
                             }

--- a/Night-Core-Player/Services/DemoMusicKitService.swift
+++ b/Night-Core-Player/Services/DemoMusicKitService.swift
@@ -1,0 +1,130 @@
+import Foundation
+import MusicKit
+
+/// -DEMO 起動引数時のみ composition root から注入される MusicKit スタブ。
+/// シミュレータは FairPlay 非対応のため Apple Music のカタログ・ライブラリ系 API が機能しないので、
+/// カタログ取得系のみシードデータを返し、再生指示は既存の MPMusicPlayerAdapter 経由へそのまま流す。
+/// MusicAuthorization.request() は ensureAuth を no-op にすることで迂回する。
+struct DemoMusicKitService: MusicKitService {
+    private struct DemoTrack {
+        let id: String
+        let title: String
+        let artist: String
+        let duration: TimeInterval
+    }
+
+    private struct DemoPlaylist {
+        let id: String
+        let name: String
+        let trackIDs: [String]
+    }
+
+    private static let demoTracks: [DemoTrack] = [
+        DemoTrack(id: "demo-song-001", title: "夜間飛行", artist: "Lumen Sky", duration: 213),
+        DemoTrack(id: "demo-song-002", title: "Midnight Circuit", artist: "電光都市エキスポ", duration: 187),
+        DemoTrack(id: "demo-song-003", title: "星屑ラビリンス", artist: "Aozora Collective", duration: 244),
+        DemoTrack(id: "demo-song-004", title: "Neon Rainfall", artist: "夜光アンサンブル", duration: 198),
+        DemoTrack(id: "demo-song-005", title: "朝焼けテレスコープ", artist: "Lumen Sky", duration: 226),
+        DemoTrack(id: "demo-song-006", title: "Gravity Zero Dance", artist: "プラズマ少年団", duration: 205)
+    ]
+
+    private static let demoPlaylists: [DemoPlaylist] = [
+        DemoPlaylist(
+            id: "demo-playlist-001",
+            name: "深夜ドライブ",
+            trackIDs: ["demo-song-001", "demo-song-002", "demo-song-004"]
+        ),
+        DemoPlaylist(
+            id: "demo-playlist-002",
+            name: "朝のリセット",
+            trackIDs: ["demo-song-005", "demo-song-003", "demo-song-006"]
+        )
+    ]
+
+    private static let seedSongs: [Song] = demoTracks.compactMap { track in
+        Self.makeItem(
+            Song.self,
+            id: track.id,
+            kind: "songs",
+            attributes: [
+                "name": track.title,
+                "artistName": track.artist,
+                "durationInMillis": Int(track.duration * 1000)
+            ]
+        )
+    }
+
+    private static let seedArtists: [Artist] = {
+        let names = Array(Set(demoTracks.map(\.artist))).sorted()
+        return names.enumerated().compactMap { index, name in
+            Self.makeItem(Artist.self, id: "demo-artist-\(index + 1)", kind: "artists", attributes: ["name": name])
+        }
+    }()
+
+    private static let seedPlaylists: [Playlist] = demoPlaylists.compactMap { playlist in
+        Self.makeItem(Playlist.self, id: playlist.id, kind: "playlists", attributes: ["name": playlist.name])
+    }
+
+    // MARK: - MusicKitService
+
+    func ensureAuth() async throws {}
+
+    func searchSongs(keyword: String, limit: Int, offset: Int) async throws -> [Song] {
+        Array(Self.matchedSongs(keyword: keyword).dropFirst(offset).prefix(limit))
+    }
+
+    func searchArtists(keyword: String, limit: Int) async throws -> [Artist] {
+        let matched = Self.seedArtists.filter { $0.name.localizedCaseInsensitiveContains(keyword) }
+        return Array(matched.prefix(limit))
+    }
+
+    func fetchArtistTopSongs(artist: Artist) async throws -> [Song] {
+        Array(Self.artistSongs(of: artist).prefix(25))
+    }
+
+    func fetchArtistSongs(artist: Artist, limit: Int, offset: Int) async throws -> [Song] {
+        Array(Self.artistSongs(of: artist).dropFirst(offset).prefix(limit))
+    }
+
+    func fetchLibraryPlaylists(limit: Int) async throws -> [Playlist] {
+        Array(Self.seedPlaylists.prefix(limit))
+    }
+
+    func fetchPlaylistSongs(in playlist: Playlist) async throws -> [Song] {
+        guard let demoPlaylist = Self.demoPlaylists.first(where: { $0.id == playlist.id.rawValue }) else {
+            return []
+        }
+        let ids = Set(demoPlaylist.trackIDs)
+        return Self.seedSongs.filter { ids.contains($0.id.rawValue) }
+    }
+
+    func fetchPersonalRecommendations(limit: Int) async throws -> [Song] {
+        Array(Self.seedSongs.shuffled().prefix(limit))
+    }
+
+    // MARK: - Private
+
+    private static func matchedSongs(keyword: String) -> [Song] {
+        seedSongs.filter { song in
+            song.title.localizedCaseInsensitiveContains(keyword)
+                || song.artistName.localizedCaseInsensitiveContains(keyword)
+        }
+    }
+
+    private static func artistSongs(of artist: Artist) -> [Song] {
+        seedSongs.filter { $0.artistName == artist.name }
+    }
+
+    /// MusicKit の Song/Artist/Playlist は public init を持たないため、Apple Music API 形式の JSON 経由で生成する
+    private static func makeItem<T: Decodable>(
+        _ type: T.Type,
+        id: String,
+        kind: String,
+        attributes: [String: Any]
+    ) -> T? {
+        let object: [String: Any] = ["id": id, "type": kind, "attributes": attributes]
+        guard let data = try? JSONSerialization.data(withJSONObject: object),
+              let item = try? JSONDecoder().decode(type, from: data) else { return nil }
+        return item
+    }
+}

--- a/Night-Core-PlayerUITests/DemoUITests.swift
+++ b/Night-Core-PlayerUITests/DemoUITests.swift
@@ -58,6 +58,32 @@ final class DemoUITests: XCTestCase {
         attachScreenshot(app, name: "06-miniplayer")
     }
 
+    /// 全画面のスクショ巡回（カタログ初期整備用）。タブ順: 0=Player 1=Search 2=Playlist 3=Settings
+    @MainActor
+    func testScreensCatalog() throws {
+        let app = XCUIApplication()
+        app.launchArguments += ["-DEMO"]
+        app.launch()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 10))
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 10))
+
+        attachScreenshot(app, name: "01-player")
+
+        tabBar.buttons.element(boundBy: 1).tap()
+        XCTAssertTrue(app.textFields["search_field"].waitForExistence(timeout: 10))
+        attachScreenshot(app, name: "02-search")
+
+        tabBar.buttons.element(boundBy: 2).tap()
+        sleep(1)
+        attachScreenshot(app, name: "03-playlist")
+
+        tabBar.buttons.element(boundBy: 3).tap()
+        sleep(1)
+        attachScreenshot(app, name: "04-settings")
+    }
+
     @MainActor
     private func attachScreenshot(_ app: XCUIApplication, name: String) {
         let attachment = XCTAttachment(screenshot: app.screenshot())

--- a/Night-Core-PlayerUITests/DemoUITests.swift
+++ b/Night-Core-PlayerUITests/DemoUITests.swift
@@ -16,6 +16,46 @@ final class DemoUITests: XCTestCase {
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 10))
         attachScreenshot(app, name: "01-launch")
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 10))
+
+        // 検索タブで検索語を入力（タブ名はローカライズされるためインデックスで選択: 0=Player 1=Search 2=Playlist 3=Settings）
+        tabBar.buttons.element(boundBy: 1).tap()
+        let searchField = app.textFields["search_field"]
+        XCTAssertTrue(searchField.waitForExistence(timeout: 10))
+        attachScreenshot(app, name: "02-search")
+        searchField.tap()
+        searchField.typeText("Lumen")
+
+        // 結果表示待ち（検索は debounce 500ms）
+        let firstSongRow = app.buttons["search_result_song"].firstMatch
+        XCTAssertTrue(firstSongRow.waitForExistence(timeout: 10))
+        attachScreenshot(app, name: "03-search-results")
+
+        // 曲をタップして再生画面へ
+        firstSongRow.tap()
+        XCTAssertTrue(app.staticTexts["夜間飛行"].waitForExistence(timeout: 10))
+        attachScreenshot(app, name: "04-player")
+
+        // 速度ボタンで倍速変更（初期レートは復元値次第なので「表示が変わる」ことだけ見る）
+        let speedUpButton = app.buttons["speed_increase_large"]
+        XCTAssertTrue(speedUpButton.waitForExistence(timeout: 10))
+        let rateLabel = app.staticTexts["playback_rate_label"]
+        let rateChanged = expectation(
+            for: NSPredicate(format: "label != %@", rateLabel.label),
+            evaluatedWith: rateLabel
+        )
+        speedUpButton.tap()
+        speedUpButton.tap()
+        wait(for: [rateChanged], timeout: 10)
+        attachScreenshot(app, name: "05-player-speed")
+
+        // 検索タブに戻りミニプレイヤーを確認
+        tabBar.buttons.element(boundBy: 1).tap()
+        let miniPlayer = app.descendants(matching: .any)["mini_player"].firstMatch
+        XCTAssertTrue(miniPlayer.waitForExistence(timeout: 10))
+        attachScreenshot(app, name: "06-miniplayer")
     }
 
     @MainActor

--- a/Night-Core-PlayerUITests/DemoUITests.swift
+++ b/Night-Core-PlayerUITests/DemoUITests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+/// デモ録画用のUIテスト。scripts/record-demo.sh から -only-testing で実行される。
+/// 通常のテスト実行（make test / CI）からは除外されている（スキーム側で skipped）。
+final class DemoUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testDemoScenario() throws {
+        let app = XCUIApplication()
+        app.launchArguments += ["-DEMO"]
+        app.launch()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 10))
+        attachScreenshot(app, name: "01-launch")
+    }
+
+    @MainActor
+    private func attachScreenshot(_ app: XCUIApplication, name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/docs/conventions/pr-assets.md
+++ b/docs/conventions/pr-assets.md
@@ -1,0 +1,103 @@
+# PR 成果物（スクリーンショット・デモ動画）の置き場
+
+- 前提: 自リポジトリの PR 運用規約（UI に変更がある PR はスクショとデモ動画を本文に添付する、という取り決め）。本書はその置き場・埋め込み形式の詳細を定める
+- スクショ等の PR 成果物は **main にも feature ブランチにも入れない**（画像を通常のコミット履歴に混ぜると main の肥大化を招くため）。orphan ブランチ `pr-assets`（merge しない）の `pr-<PR番号>/<名前>.png` 配下に置く
+- デモ動画の作り方は `scripts/record-demo.sh` のヘッダコメントを参照
+
+## ブランチの構造
+
+```
+pr-assets
+├── pr-<番号>/          # PR ごとの証跡。一度置いたら動かさない
+├── features/
+│   ├── <機能>/
+│   │   ├── demo.gif    # その機能の最新デモ動画（merge 時に上書き更新）
+│   │   ├── demo.mp4
+│   │   ├── screens/    # 画面ごとの最新スクショ（画面キー単位で上書き更新）
+│   │   └── meta.json   # 索引の生成元（出典 PR・昇格日）
+│   └── README.md       # カタログ索引（自動生成）
+└── README.md           # ブランチの運用説明（人が書く）
+```
+
+- **役割の書き分け**: `pr-<番号>/` は **その PR の証跡**（不変。一度置いたら書き換えない）、`features/` は **機能ごとの最新カタログ**（merge のたびに上書きされる）
+- `pr-<番号>/` から `features/` へは **移動ではなくコピー**する。過去 PR の本文が `pr-<番号>/` へのリンクで成り立っているため、移動するとリンクが壊れる
+- **自動生成が書き込むのは `features/` 配下だけ**。ルートの `README.md` は人が書くもので、生成スクリプトは触らない
+
+## 埋め込み形式
+
+PR 本文への埋め込みは次の形式を使う:
+
+```
+https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-<番号>/<名前>.png?raw=true
+```
+
+- **`raw.githubusercontent.com` への直リンクは使わない**。private リポジトリでは表示されない
+- `blob/<branch>/<path>?raw=true` 形式は、ログイン済みメンバーには inline 表示される
+
+### 動画（GIF / mp4）
+
+同じ形式で GIF と mp4 の両方を置き、**GIF をインライン画像、mp4 をリンク**として本文に貼る:
+
+```markdown
+![会員が今日の振り返りを保存する](https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-<番号>/daily-log.gif?raw=true)
+
+[▶ フル解像度の動画（mp4）](https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-<番号>/daily-log.mp4?raw=true)
+```
+
+- GIF は PR 上でぱっと見るための倍速・低解像度版、mp4 は等倍のじっくり確認用。mp4 のリンクは GitHub のファイルビューアが内蔵プレーヤーで再生する
+- **mp4 を Markdown でインライン再生させることはできない**。インライン動画になるのは GitHub の Web UI にドラッグ&ドロップして得られる `user-attachments` の URL だけで、そのアップロード API は非公開のため自動化できない（[community#29993](https://github.com/orgs/community/discussions/29993)）。人間がレビュー時に手で貼れば本物のプレーヤーになるので、必要ならそこだけ手動で格上げする
+
+## 機能カタログ（features/）
+
+`pr-assets` ブランチの `features/` を GitHub で開くと索引が描画され、**全機能の最新デモ・画面スクショの一覧**として読める。`features/` 配下は PR が merge されたときに `pr-<番号>/manifest.json` を読んで自動更新される（`.github/workflows/demo-catalog.yml`）。**手で編集しない**（次の merge で上書きされる）。
+
+`manifest.json` は録画スクリプトが生成する。PR に動画を添付するときは、GIF・mp4 と一緒にこれも `pr-<番号>/` に置く（置き忘れると動画は PR に残るがカタログには載らない）。
+
+**動画と `manifest.json` は PR を作る時点で `pr-assets` に push しておく**。カタログの更新は merge 時に走るので、その時点で `pr-<番号>/` が無いと昇格は黙って飛ぶ（エラーにはならない）。取りこぼしたら `demo-catalog` ワークフローを `workflow_dispatch` で PR 番号を指定して再実行すればよい。
+
+### manifest.json の形式
+
+```json
+{
+  "prNumber": 305,
+  "entries": [
+    {
+      "feature": "daily-log",
+      "title": "会員が今日の振り返りを保存すると、一覧に反映される",
+      "roles": ["member"],
+      "gif": "daily-log.gif",
+      "mp4": "daily-log.mp4"
+    }
+  ],
+  "screenshots": [
+    {
+      "feature": "daily-log",
+      "screen": "thread",
+      "state": "sent",
+      "file": "02-thread-sent.png",
+      "caption": "メッセージ送信後のスレッド"
+    }
+  ]
+}
+```
+
+- `entries`（動画）は録画スクリプトが書く。`screenshots` は **手で追記してよい**（スクショは手撮り運用なので、録画スクリプトは生成しない）。動画が無い PR では `manifest.json` を手書きしてよい（`entries` を空配列にする）
+- `feature` は `[a-z0-9-]+`。`screen` / `state` は `[a-z0-9]+(-[a-z0-9]+)*` で、**連続ハイフン `--` と先頭・末尾のハイフンは使えない**（昇格先の名前を `<screen>--<state>` で組み立てるため、`--` を許すと `screen: "a--b"` と `screen: "a"` + `state: "b"` が同じ画面に潰れて上書きし合う）
+- `state` は省略可（`empty` / `error` / `dialog` のような状態を区別したいときだけ付ける）
+- `file` は `pr-<番号>/` に置いた実ファイル名（`png` / `jpg` / `jpeg` / `webp`）。`caption` は索引にそのまま出る1行の説明
+- `caption` と `title` は**プレーンテキストとして描画される**。Markdown・HTML を書いても記法としては効かず、記号がそのまま表示される（キャプションから索引の構造を壊せないようにするため）
+
+### 動画とスクショの更新単位の違い
+
+- **動画は機能まるごと置き換え**。コピー先は `demo.gif` / `demo.mp4` に固定されるので、元の名前が変わっても孤児は残らない
+- **スクショは画面キー単位の上書き**。`features/<機能>/screens/<screen>[--<state>].<拡張子>` へ昇格し、**キーが一致するものだけ**が差し替わる（今回の PR に含まれない画面のスクショはそのまま残る）。同じキーで拡張子が変わったときは旧ファイルを消す
+- `meta.json` にはスクショごとの出典 PR と昇格日が入り、索引 `features/README.md` にも出典として描画される。**カタログのスクショの古さは、索引に書かれた出典 PR と日付で判断する**（画像自体には更新日が写らないため）
+- 昇格日は「その画像が入れ替わった日」。同じ PR の同じ画像を昇格し直すだけ（`workflow_dispatch` での再実行・push 競合のリトライ）なら据え置かれるので、再実行でカタログが新しく見えることはない
+
+## 運用ルール
+
+- **PR で画面の見た目を変えたら、その画面のスクショを画面キー付きで `manifest.json` の `screenshots` に載せる**。PR 本文に貼るだけでは証跡（`pr-<番号>/`）にしか残らず、カタログは古い見た目のままになる
+- **`pr-assets` ブランチは削除しない**。削除すると過去 PR の画像が壊れる
+- **feature ブランチ上に画像を置いて参照する方式は使わない**。merge 後にブランチが削除されると PR 上の画像リンクが壊れる
+- **`docs/` 配下に PR スクショを置かない**。main に画像が残り続けるため
+- 既存の置き場一覧は `pr-assets` ブランチのディレクトリを直接見る（ここに列挙すると陳腐化するため書かない）

--- a/scripts/build-demo-catalog.ts
+++ b/scripts/build-demo-catalog.ts
@@ -1,0 +1,797 @@
+// pr-assets ブランチの `pr-<番号>/manifest.json` を読み、機能ごとの最新デモ（動画）と
+// 画面ごとの最新スクリーンショットを `features/<機能>/` へコピーして索引 `features/README.md` を
+// 再生成する（conventions/pr-assets.md「機能カタログ」）。
+//
+// 実行: node scripts/build-demo-catalog.ts --assets-dir <pr-assets の作業コピー> --pr <番号>
+//
+// Why not: 依存を一切使わない（zod も tsx も）。このスクリプトは pr-assets への書き込み権限を
+// 持つ唯一のジョブから実行されるため、`pnpm install` を挟むと lifecycle script が書き込み
+// トークンを持つ環境で動く。node 標準 API だけで書き、Node の型ストリップで直接実行する。
+//
+// 書き込むのは features/ 配下だけ。pr-<番号>/ は読み取り専用（過去 PR のリンクが張られている）で、
+// ルートの README.md は人が書くもの（同ドキュメント）なので触らない。
+//
+// 既知の制約: merge 順とワークフローの実行順が逆転すると、一時的に古い方のデモが「最新」として
+// 並ぶ。次回その機能が更新された時点で正しくなる自己修復的な不整合なので、順序制御はしていない。
+import fs from "node:fs";
+import path from "node:path";
+
+const REPO = "MizuRyu/NightCorePlayer";
+const ASSETS_BRANCH = "pr-assets";
+const FEATURES_DIR_NAME = "features";
+const SCREENS_DIR_NAME = "screens";
+const META_FILE_NAME = "meta.json";
+const README_FILE_NAME = "README.md";
+const GENERATOR = "scripts/build-demo-catalog.ts";
+
+// コピー先のファイル名は固定する。元の名前を引き継ぐと、名前が変わる更新
+// （daily-log.gif → daily-log-v2.gif）のたびに旧ファイルが孤児として残り、
+// 「features/<機能>/ は常に最新のデモ」という不変条件が崩れるため。
+const CATALOG_GIF_NAME = "demo.gif";
+const CATALOG_MP4_NAME = "demo.mp4";
+
+/** ディレクトリ名・ロール名に許す文字。`..` や `/` の混入を入口で断つ。 */
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+/**
+ * 画面キーの部品（screen / state）に許す文字。SLUG_PATTERN より狭く、連続ハイフンと
+ * 先頭・末尾のハイフンを禁じる。`<screen>--<state>` で組み立てるキーが単射でなくなると、
+ * screen="a--b" と screen="a" state="b" が同じキーに潰れ、別の画面を上書き・削除してしまう。
+ */
+const SCREEN_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** 昇格日。`YYYY-MM-DD` だけを許し、索引にそのまま埋め込む。 */
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * スクショに許す拡張子。
+ * Why not: 動画のように `demo.gif` へ名前を固定しない（拡張子を揃えるには変換が必要で、
+ * 依存なしでは書けない）。代わりに画面キーで名前を決め、拡張子が変わったら旧ファイルを消す。
+ */
+const SCREENSHOT_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp"] as const;
+
+export interface DemoManifestEntry {
+  feature: string;
+  title: string;
+  roles: string[];
+  gif: string;
+  mp4: string;
+}
+
+/**
+ * 手撮りのスクショ1枚。動画がストーリーを見せるのに対し、こちらは画面・状態のカット
+ * （empty / error / dialog 等）を見せる。`screen` + `state` が「どの画面のどの状態か」の
+ * 識別子で、この単位で最新版に差し替える。
+ */
+export interface DemoManifestScreenshot {
+  feature: string;
+  screen: string;
+  /** 状態の区別が不要な画面では null（`<screen>.png` として昇格する）。 */
+  state: string | null;
+  file: string;
+  caption: string;
+}
+
+export interface DemoManifest {
+  /**
+   * 録画は PR を作る前に走るため、この時点では番号が無い（record-demo.ts は `--pr` 未指定で
+   * null を書く）。権威は「どの pr-<番号>/ から読んだか」であり、ここは参考情報にすぎない。
+   */
+  prNumber: number | null;
+  entries: DemoManifestEntry[];
+  /** 未指定の manifest（動画だけの PR・スクショ機能より前に作られたもの）では空配列。 */
+  screenshots: DemoManifestScreenshot[];
+}
+
+/**
+ * 動画とその出典。スクショだけが載っている機能では丸ごと欠けるため、
+ * 「全部あり or 全部なし」を型で表す（title だけある meta のような中間状態を作らない）。
+ */
+export interface FeatureVideo {
+  title: string;
+  roles: string[];
+  gif: string;
+  mp4: string;
+  prNumber: number;
+}
+
+/** 昇格済みのスクショ1枚。出典 PR と昇格日を持たせ、索引で古さが見えるようにする。 */
+export interface FeatureScreen {
+  screen: string;
+  state: string | null;
+  file: string;
+  caption: string;
+  prNumber: number;
+  promotedAt: string;
+}
+
+/**
+ * `features/<機能>/meta.json`。索引はこれだけを読んで再生成する（README を逆パースしない）。
+ * JSON 上は動画系フィールドが平坦に並ぶ（`{feature, title, roles, gif, mp4, prNumber, screens}`）。
+ * 既存ファイルとの互換のため形は変えず、読み書きの境界で video へ束ね直している。
+ */
+export interface FeatureMeta {
+  feature: string;
+  video: FeatureVideo | null;
+  screens: FeatureScreen[];
+}
+
+export interface CatalogPlan {
+  copies: { from: string; to: string }[];
+  /** 同じ画面キーで拡張子が変わったときの旧ファイル（参照されない画像を screens/ に残さない）。 */
+  deletions: string[];
+  metaWrites: { path: string; meta: FeatureMeta }[];
+  readme: { path: string; content: string } | null;
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail(`${label} がオブジェクトではない`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireSlug(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SLUG_PATTERN.test(value)) {
+    fail(`${label} は ${SLUG_PATTERN.source} に一致する必要がある: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function requireScreenSlug(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SCREEN_SLUG_PATTERN.test(value)) {
+    fail(
+      `${label} は ${SCREEN_SLUG_PATTERN.source} に一致する必要がある: ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+/** 状態（empty / error 等）は任意。未指定と「状態の区別なし」を同じ null に寄せる。 */
+function requireOptionalScreenSlug(value: unknown, label: string): string | null {
+  if (value === null || value === undefined) return null;
+  return requireScreenSlug(value, label);
+}
+
+function requireDate(value: unknown, label: string): string {
+  if (typeof value !== "string" || !DATE_PATTERN.test(value)) {
+    fail(`${label} は YYYY-MM-DD でなければならない: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/**
+ * ファイル名として安全であることを確認する。パス区切り・`..` を弾いた上で拡張子まで固定し、
+ * pr-<番号>/ の外を読ませない・features/<機能>/ の外へ書かせない。
+ */
+function requireFileName(value: unknown, extension: string, label: string): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) {
+    fail(`${label} がファイル名として不正: ${JSON.stringify(value)}`);
+  }
+  if (value.includes("..") || value.includes("/") || value.includes("\\")) {
+    fail(`${label} にパス区切りまたは .. が含まれる: ${value}`);
+  }
+  if (!value.endsWith(extension)) {
+    fail(`${label} の拡張子は ${extension} でなければならない: ${value}`);
+  }
+  return value;
+}
+
+/** 許可拡張子のどれで終わるかを返す。コピー先はこの拡張子をそのまま引き継ぐ。 */
+function screenshotExtension(file: string, label: string): string {
+  const extension = SCREENSHOT_EXTENSIONS.find((candidate) => file.endsWith(candidate));
+  if (extension === undefined) {
+    fail(
+      `${label} の拡張子は ${SCREENSHOT_EXTENSIONS.join(" / ")} のいずれかでなければならない: ${file}`,
+    );
+  }
+  return extension;
+}
+
+function requireScreenshotFileName(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    fail(`${label} がファイル名として不正: ${JSON.stringify(value)}`);
+  }
+  return requireFileName(value, screenshotExtension(value, label), label);
+}
+
+/** 索引 Markdown へそのまま埋め込む文字列。改行・記号での構造破壊を防ぐ。 */
+function requireTitle(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    fail(`${label} が空`);
+  }
+  if (/[\r\n]/.test(value)) {
+    fail(`${label} に改行が含まれる`);
+  }
+  return value.trim();
+}
+
+/**
+ * Why not: 空配列を弾かない。このスクリプトが走るのは merge された後で、ここで落としても
+ * PR をやり直せない（ロール未検出は索引の見栄えの問題でしかない）。録画時点で落とすべき
+ * 検証は録画スクリプト側に置く。パストラバーサル系は事後でも落とすべきなので厳格なまま。
+ */
+function requireRoles(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) {
+    fail(`${label} が配列ではない`);
+  }
+  return value.map((role, index) => requireSlug(role, `${label}[${index}]`));
+}
+
+function requirePrNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    fail(`${label} は正の整数でなければならない: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function parseEntry(raw: unknown, label: string): DemoManifestEntry {
+  const entry = asRecord(raw, label);
+  return {
+    feature: requireSlug(entry.feature, `${label}.feature`),
+    title: requireTitle(entry.title, `${label}.title`),
+    roles: requireRoles(entry.roles, `${label}.roles`),
+    gif: requireFileName(entry.gif, ".gif", `${label}.gif`),
+    mp4: requireFileName(entry.mp4, ".mp4", `${label}.mp4`),
+  };
+}
+
+function parseScreenshot(raw: unknown, label: string): DemoManifestScreenshot {
+  const screenshot = asRecord(raw, label);
+  return {
+    feature: requireSlug(screenshot.feature, `${label}.feature`),
+    screen: requireScreenSlug(screenshot.screen, `${label}.screen`),
+    state: requireOptionalScreenSlug(screenshot.state, `${label}.state`),
+    file: requireScreenshotFileName(screenshot.file, `${label}.file`),
+    caption: requireTitle(screenshot.caption, `${label}.caption`),
+  };
+}
+
+/**
+ * 「どの画面のどの状態か」を1本の文字列にする。昇格先のファイル名（拡張子を除く）と同じで、
+ * 上書き対象の突き合わせ・並び順の正規化もこのキーで行う。
+ */
+function screenKey(screen: { screen: string; state: string | null }): string {
+  return screen.state === null ? screen.screen : `${screen.screen}--${screen.state}`;
+}
+
+export function parseDemoManifest(raw: unknown): DemoManifest {
+  const manifest = asRecord(raw, "manifest");
+  const prNumber =
+    manifest.prNumber === null || manifest.prNumber === undefined
+      ? null
+      : requirePrNumber(manifest.prNumber, "manifest.prNumber");
+  if (!Array.isArray(manifest.entries)) {
+    fail("manifest.entries が配列ではない");
+  }
+
+  const entries = manifest.entries.map((entry, index) =>
+    parseEntry(entry, `manifest.entries[${index}]`),
+  );
+  const features = new Set(entries.map((entry) => entry.feature));
+  if (features.size !== entries.length) {
+    fail("manifest.entries に同じ feature が重複している（どちらが最新か決められない）");
+  }
+
+  // screenshots は後から足した項目なので、未指定を空配列として扱う（既存の manifest を読めなくしない）。
+  const rawScreenshots = manifest.screenshots ?? [];
+  if (!Array.isArray(rawScreenshots)) {
+    fail("manifest.screenshots が配列ではない");
+  }
+  const screenshots = rawScreenshots.map((screenshot, index) =>
+    parseScreenshot(screenshot, `manifest.screenshots[${index}]`),
+  );
+  const screenKeys = new Set(screenshots.map((shot) => `${shot.feature}/${screenKey(shot)}`));
+  if (screenKeys.size !== screenshots.length) {
+    fail("manifest.screenshots に同じ機能・画面・状態が重複している（昇格先が衝突する）");
+  }
+
+  return { prNumber, entries, screenshots };
+}
+
+function parseFeatureScreen(raw: unknown, label: string): FeatureScreen {
+  const screen = asRecord(raw, label);
+  const parsed = {
+    screen: requireScreenSlug(screen.screen, `${label}.screen`),
+    state: requireOptionalScreenSlug(screen.state, `${label}.state`),
+    file: requireScreenshotFileName(screen.file, `${label}.file`),
+    caption: requireTitle(screen.caption, `${label}.caption`),
+    prNumber: requirePrNumber(screen.prNumber, `${label}.prNumber`),
+    promotedAt: requireDate(screen.promotedAt, `${label}.promotedAt`),
+  };
+
+  // 昇格したファイル名は画面キーそのもの。食い違う meta を信じると、ある画面の更新で
+  // 別の画面の画像を「旧ファイル」として消してしまう。
+  const expected = `${screenKey(parsed)}${screenshotExtension(parsed.file, `${label}.file`)}`;
+  if (parsed.file !== expected) {
+    fail(`${label}.file が画面キーと一致しない（${expected} のはず）: ${parsed.file}`);
+  }
+  return parsed;
+}
+
+/**
+ * 動画系フィールドは「全部あり or 全部なし」。スクショだけの機能では丸ごと欠けるので
+ * 不在を許すが、一部だけ欠けた meta は生成側の壊れ方なので落とす。
+ */
+function parseFeatureVideo(meta: Record<string, unknown>, label: string): FeatureVideo | null {
+  const keys = ["title", "roles", "gif", "mp4", "prNumber"] as const;
+  const present = keys.filter((key) => meta[key] !== undefined);
+  if (present.length === 0) return null;
+  if (present.length !== keys.length) {
+    fail(`${label} の動画フィールドが揃っていない（あるのは ${present.join(", ")}）`);
+  }
+
+  return {
+    title: requireTitle(meta.title, `${label}.title`),
+    roles: requireRoles(meta.roles, `${label}.roles`),
+    gif: requireFileName(meta.gif, ".gif", `${label}.gif`),
+    mp4: requireFileName(meta.mp4, ".mp4", `${label}.mp4`),
+    prNumber: requirePrNumber(meta.prNumber, `${label}.prNumber`),
+  };
+}
+
+export function parseFeatureMeta(raw: unknown, label: string): FeatureMeta {
+  const meta = asRecord(raw, label);
+  const feature = requireSlug(meta.feature, `${label}.feature`);
+  const video = parseFeatureVideo(meta, label);
+
+  const rawScreens = meta.screens ?? [];
+  if (!Array.isArray(rawScreens)) {
+    fail(`${label}.screens が配列ではない`);
+  }
+  const screens = rawScreens.map((screen, index) =>
+    parseFeatureScreen(screen, `${label}.screens[${index}]`),
+  );
+  if (new Set(screens.map(screenKey)).size !== screens.length) {
+    fail(`${label}.screens に同じ画面・状態が重複している（どちらが最新か決められない）`);
+  }
+
+  // 中身の無い meta は索引に見出しだけを生む。生成側の不具合をここで止める。
+  if (video === null && screens.length === 0) {
+    fail(`${label} に動画もスクリーンショットも無い`);
+  }
+
+  return { feature, video, screens };
+}
+
+/** 解決後の絶対パスが features/ 配下に収まっていることを保証する多層防御の最終段。 */
+function resolveInFeatures(featuresDir: string, ...segments: string[]): string {
+  const resolved = path.resolve(featuresDir, ...segments);
+  if (!resolved.startsWith(`${path.resolve(featuresDir)}${path.sep}`)) {
+    fail(`書き込み先が features/ の外を指している: ${resolved}`);
+  }
+  return resolved;
+}
+
+function assetUrl(...segments: string[]): string {
+  return `https://github.com/${REPO}/blob/${ASSETS_BRANCH}/${segments.join("/")}?raw=true`;
+}
+
+function pullRequestUrl(prNumber: number): string {
+  return `https://github.com/${REPO}/pull/${prNumber}`;
+}
+
+/** CommonMark でエスケープが効く ASCII 記号のうち、索引の構造を壊しうるもの。 */
+const MARKDOWN_PUNCTUATION = /[\\[\]()*_~`#+\-.!>|]/g;
+
+/**
+ * 索引に埋め込む自由文（タイトル・キャプション）を、記法として解釈されない1つの文字列にする。
+ * これらはテスト名や人の手書きから来るので、記法を含みうる。
+ *
+ * Why not: 危ない記法を列挙して潰さない（行頭の `#` だけ、`]` だけ…）。`~~~` の未閉フェンス・
+ * 行中の `![x](url)` のように後から穴が見つかり続けるため、意味を持つ記号を位置に関わらず
+ * 全てバックスラッシュエスケープする。GitHub の描画では記号そのものとして出るので見た目は変わらない。
+ * インライン HTML（`<!--` は以降のカタログ全体を不可視にする）だけはバックスラッシュが効かないので、
+ * 先に実体参照へ逃がす。
+ */
+function escapeMarkdownText(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(MARKDOWN_PUNCTUATION, (character) => `\\${character}`);
+}
+
+function renderVideoBlock(dir: string, video: FeatureVideo): string[] {
+  const roles = video.roles.map((role) => `\`${role}\``).join(" ");
+  return [
+    "",
+    escapeMarkdownText(video.title),
+    // ロール未検出のデモでも索引には載せる（空行だけの行を残さない）
+    ...(roles === "" ? [] : ["", `ロール: ${roles}`]),
+    "",
+    `![${escapeMarkdownText(video.title)}](${assetUrl(dir, video.gif)})`,
+    "",
+    `[▶ フル解像度の動画（mp4）](${assetUrl(dir, video.mp4)}) ・ 出典: [#${video.prNumber}](${pullRequestUrl(video.prNumber)})`,
+  ];
+}
+
+/** スクショは画面ごとに出典 PR と昇格日を添える（動画と更新タイミングが別なので古さが読めるように）。 */
+function renderScreenBlock(dir: string, screen: FeatureScreen): string[] {
+  return [
+    "",
+    `![${escapeMarkdownText(screen.caption)}](${assetUrl(dir, SCREENS_DIR_NAME, screen.file)})`,
+    "",
+    `${escapeMarkdownText(screen.caption)} ・ 出典: [#${screen.prNumber}](${pullRequestUrl(screen.prNumber)})（${screen.promotedAt}）`,
+  ];
+}
+
+function renderFeatureSection(meta: FeatureMeta): string {
+  const dir = `${FEATURES_DIR_NAME}/${meta.feature}`;
+  return [
+    `## ${meta.feature}`,
+    ...(meta.video === null ? [] : renderVideoBlock(dir, meta.video)),
+    ...meta.screens.flatMap((screen) => renderScreenBlock(dir, screen)),
+  ].join("\n");
+}
+
+export function renderCatalogReadme(metas: FeatureMeta[]): string {
+  // Why not: localeCompare で並べない（実行環境の ICU で順序が変わり、生成のたびに無駄な差分が出る）。
+  const sorted = [...metas].sort((a, b) =>
+    a.feature < b.feature ? -1 : a.feature > b.feature ? 1 : 0,
+  );
+
+  const sections = sorted.map(renderFeatureSection);
+  const body = sections.length > 0 ? sections : ["まだ登録された機能デモはありません。"];
+
+  return [
+    `<!-- このファイルは ${GENERATOR} が自動生成する。手で編集しない（次の merge で上書きされる）。 -->`,
+    "",
+    "# 機能デモカタログ",
+    "",
+    "機能ごとの最新デモ（E2E のメインストーリーの録画）と、画面ごとの最新スクリーンショット。PR が merge されるたびに自動更新される。",
+    // （docs/conventions/pr-assets.md はこのテンプレの conventions/pr-assets.md を配置した先）。
+    `運用は [docs/conventions/pr-assets.md](https://github.com/${REPO}/blob/main/docs/conventions/pr-assets.md) を参照。`,
+    "",
+    ...body.flatMap((section, index) => (index === 0 ? [section] : ["", section])),
+    "",
+  ].join("\n");
+}
+
+/** Why not: localeCompare で並べない（実行環境の ICU で順序が変わり、生成のたびに無駄な差分が出る）。 */
+function sortScreens(screens: FeatureScreen[]): FeatureScreen[] {
+  return [...screens].sort((a, b) => {
+    const [left, right] = [screenKey(a), screenKey(b)];
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+}
+
+export function planCatalogUpdate(input: {
+  manifest: DemoManifest | null;
+  /** 読み込み元 pr-<番号>/ の番号。manifest 内の prNumber ではなくこちらが権威。 */
+  prNumber: number;
+  existingMetas: FeatureMeta[];
+  /** スクショの昇格日（`YYYY-MM-DD`）。生成を決定的にするため呼び出し側から渡す。 */
+  promotedAt: string;
+  assetsDir: string;
+}): CatalogPlan {
+  const { manifest, prNumber, existingMetas, promotedAt, assetsDir } = input;
+  if (manifest === null) {
+    return { copies: [], deletions: [], metaWrites: [], readme: null };
+  }
+
+  const featuresDir = path.join(assetsDir, FEATURES_DIR_NAME);
+  const prDir = path.join(assetsDir, `pr-${prNumber}`);
+
+  const copies: CatalogPlan["copies"] = [];
+  const deletions: CatalogPlan["deletions"] = [];
+
+  // 既存の meta を土台に、今回の manifest が触った部分（動画一式・該当画面キー）だけを差し替える。
+  // 動画とスクショは別の PR で更新されるため、片方の更新でもう片方を落とさない。
+  const catalog = new Map(existingMetas.map((meta) => [meta.feature, meta]));
+  const touched = new Set<string>();
+  const metaOf = (feature: string): FeatureMeta =>
+    catalog.get(feature) ?? { feature, video: null, screens: [] };
+
+  for (const entry of manifest.entries) {
+    const featureDir = resolveInFeatures(featuresDir, entry.feature);
+    const renamed = [
+      [entry.gif, CATALOG_GIF_NAME],
+      [entry.mp4, CATALOG_MP4_NAME],
+    ] as const;
+    for (const [sourceName, catalogName] of renamed) {
+      copies.push({
+        from: path.join(prDir, sourceName),
+        to: resolveInFeatures(featureDir, catalogName),
+      });
+    }
+    catalog.set(entry.feature, {
+      ...metaOf(entry.feature),
+      video: {
+        title: entry.title,
+        roles: entry.roles,
+        gif: CATALOG_GIF_NAME,
+        mp4: CATALOG_MP4_NAME,
+        prNumber,
+      },
+    });
+    touched.add(entry.feature);
+  }
+
+  for (const screenshot of manifest.screenshots) {
+    const featureDir = resolveInFeatures(featuresDir, screenshot.feature);
+    const screensDir = resolveInFeatures(featureDir, SCREENS_DIR_NAME);
+    const key = screenKey(screenshot);
+    const label = `screenshots(${screenshot.feature}/${key})`;
+    const file = `${key}${screenshotExtension(screenshot.file, label)}`;
+    copies.push({
+      from: path.join(prDir, screenshot.file),
+      to: resolveInFeatures(screensDir, file),
+    });
+
+    const current = metaOf(screenshot.feature);
+    const previous = current.screens.find((screen) => screenKey(screen) === key);
+    // 同じ画面キーでも拡張子が変わると別名で置かれ、旧ファイルは誰からも参照されなくなる。
+    if (previous !== undefined && previous.file !== file) {
+      deletions.push(resolveInFeatures(screensDir, previous.file));
+    }
+    // 同じ PR の同じ画像を昇格し直す（workflow_dispatch での再実行・push 競合のリトライ）
+    // だけなら、実際に更新された日ではないので昇格日を据え置く。
+    const unchanged = previous?.prNumber === prNumber && previous?.file === file;
+    catalog.set(screenshot.feature, {
+      ...current,
+      screens: sortScreens([
+        ...current.screens.filter((screen) => screenKey(screen) !== key),
+        {
+          screen: screenshot.screen,
+          state: screenshot.state,
+          file,
+          caption: screenshot.caption,
+          prNumber,
+          promotedAt: unchanged ? previous.promotedAt : promotedAt,
+        },
+      ]),
+    });
+    touched.add(screenshot.feature);
+  }
+
+  const metaWrites = [...touched].map((feature) => ({
+    path: resolveInFeatures(resolveInFeatures(featuresDir, feature), META_FILE_NAME),
+    meta: metaOf(feature),
+  }));
+
+  return {
+    copies,
+    deletions,
+    metaWrites,
+    readme: {
+      path: resolveInFeatures(featuresDir, README_FILE_NAME),
+      content: renderCatalogReadme([...catalog.values()]),
+    },
+  };
+}
+
+// ここから下はファイルシステムに触る層。resolveInFeatures の字句チェックだけでは
+// シンボリックリンクを見抜けない（`features/daily-log -> ../pr-123` は字句上 features/ 配下だが
+// 実体は過去 PR の資産、`pr-280/x.gif -> ../.git/config` は checkout が置いた認証情報を指す）。
+// 読み書きするパスは lstat で実体の種別を確かめ、realpath でも封じ込めを検査する。
+
+function isWithin(parentReal: string, targetReal: string): boolean {
+  return targetReal === parentReal || targetReal.startsWith(`${parentReal}${path.sep}`);
+}
+
+/** 実在するディレクトリの realpath を返す。リンク・非ディレクトリ・封じ込め違反は失敗させる。 */
+function realDirectoryWithin(parentReal: string | null, dir: string, label: string): string | null {
+  const stats = fs.lstatSync(dir, { throwIfNoEntry: false });
+  if (stats === undefined) return null;
+  if (!stats.isDirectory()) {
+    fail(`${label} が実ディレクトリではない（シンボリックリンクの可能性）: ${dir}`);
+  }
+  const real = fs.realpathSync(dir);
+  if (parentReal !== null && !isWithin(parentReal, real)) {
+    fail(`${label} の実体が ${parentReal} の外を指している: ${real}`);
+  }
+  return real;
+}
+
+/** コピー元は「リンクでない通常ファイル」かつ実体が pr-<番号>/ 配下であること。 */
+function assertReadableAsset(source: string, prDirReal: string): void {
+  const stats = fs.lstatSync(source, { throwIfNoEntry: false });
+  if (stats === undefined) {
+    fail(`コピー元が見つからない: ${source}`);
+  }
+  if (!stats.isFile()) {
+    fail(`コピー元が通常ファイルではない（シンボリックリンクの可能性）: ${source}`);
+  }
+  if (!isWithin(prDirReal, fs.realpathSync(source))) {
+    fail(`コピー元の実体が ${prDirReal} の外を指している: ${source}`);
+  }
+}
+
+/**
+ * 書き込み先・削除先は features/<機能>/（または screens/）の実体配下で、既存ファイルが
+ * あるならリンクでないこと。まだ存在しない親（初回の screens/）は mkdir に任せる。
+ */
+function assertWritableTarget(target: string, featuresDirReal: string): void {
+  const parentReal = realDirectoryWithin(featuresDirReal, path.dirname(target), "書き込み先の親");
+  if (parentReal === null) return;
+
+  const stats = fs.lstatSync(target, { throwIfNoEntry: false });
+  if (stats !== undefined && !stats.isFile()) {
+    fail(`書き込み先が通常ファイルではない（シンボリックリンクの可能性）: ${target}`);
+  }
+}
+
+/**
+ * features/ 配下の meta.json を読む。ディレクトリ名と meta.feature の一致まで含めて
+ * ここで検査する（顧客向け資料の生成 scripts/build-showcase.ts も同じ入口を使う。
+ * カタログの読み取り規則を2箇所に持たないため export している）。
+ * 引数は realpath 済みのディレクトリで、null は features/ が無い状態を表す。
+ */
+export function readExistingMetas(featuresDirReal: string | null): FeatureMeta[] {
+  if (featuresDirReal === null) return [];
+
+  const metas: FeatureMeta[] = [];
+  for (const dirent of fs.readdirSync(featuresDirReal, { withFileTypes: true })) {
+    if (dirent.isSymbolicLink()) {
+      fail(`features/ の直下にシンボリックリンクがある: ${dirent.name}`);
+    }
+    if (!dirent.isDirectory()) continue;
+
+    const metaPath = path.join(featuresDirReal, dirent.name, META_FILE_NAME);
+    const stats = fs.lstatSync(metaPath, { throwIfNoEntry: false });
+    if (stats === undefined) continue;
+    if (!stats.isFile()) {
+      fail(`${metaPath} が通常ファイルではない`);
+    }
+
+    const meta = parseFeatureMeta(
+      JSON.parse(fs.readFileSync(metaPath, "utf8")),
+      `${dirent.name}/${META_FILE_NAME}`,
+    );
+    if (meta.feature !== dirent.name) {
+      fail(`${metaPath} の feature がディレクトリ名と一致しない: ${meta.feature}`);
+    }
+    metas.push(meta);
+  }
+  return metas;
+}
+
+function applyPlan(
+  plan: CatalogPlan,
+  context: { prDirReal: string; featuresDirReal: string },
+): void {
+  // 検査を全部済ませてから書き始める（途中まで書いて中断した状態を作らない）。
+  for (const copy of plan.copies) {
+    assertReadableAsset(copy.from, context.prDirReal);
+  }
+  for (const target of [
+    ...plan.copies.map((copy) => copy.to),
+    ...plan.deletions,
+    ...plan.metaWrites.map((write) => write.path),
+    ...(plan.readme ? [plan.readme.path] : []),
+  ]) {
+    assertWritableTarget(target, context.featuresDirReal);
+  }
+
+  for (const copy of plan.copies) {
+    fs.mkdirSync(path.dirname(copy.to), { recursive: true });
+    fs.copyFileSync(copy.from, copy.to);
+  }
+  // 削除はコピーの後（消す旧ファイルと今回のコピー先は画面キーが同じで拡張子だけが違うため、
+  // 名前が衝突することはない）。
+  for (const target of plan.deletions) {
+    fs.rmSync(target, { force: true });
+  }
+  for (const write of plan.metaWrites) {
+    const { feature, video, screens } = write.meta;
+    // キー順を固定して JSON の差分をファイル内容の変化だけに絞る。
+    // 空の screens は書かない（動画だけの既存 meta.json に無意味な差分を出さない）。
+    const serialized = JSON.stringify(
+      {
+        feature,
+        ...(video === null
+          ? {}
+          : {
+              title: video.title,
+              roles: video.roles,
+              gif: video.gif,
+              mp4: video.mp4,
+              prNumber: video.prNumber,
+            }),
+        ...(screens.length === 0 ? {} : { screens }),
+      },
+      null,
+      2,
+    );
+    fs.mkdirSync(path.dirname(write.path), { recursive: true });
+    fs.writeFileSync(write.path, `${serialized}\n`);
+  }
+  if (plan.readme) {
+    fs.mkdirSync(path.dirname(plan.readme.path), { recursive: true });
+    fs.writeFileSync(plan.readme.path, plan.readme.content);
+  }
+}
+
+export function buildDemoCatalog(input: { assetsDir: string; prNumber: number }): void {
+  const { prNumber } = input;
+  const assetsDirReal = realDirectoryWithin(null, input.assetsDir, "--assets-dir");
+  if (assetsDirReal === null) {
+    fail(`--assets-dir が存在しない: ${input.assetsDir}`);
+  }
+
+  const prDirReal = realDirectoryWithin(
+    assetsDirReal,
+    path.join(assetsDirReal, `pr-${prNumber}`),
+    `pr-${prNumber}/`,
+  );
+  // 動画を添付しない PR が大多数なので、pr-<番号>/ や manifest の不在は通常経路として正常終了する。
+  if (prDirReal === null) {
+    console.log(`[demo-catalog] pr-${prNumber}/ が無いため何もしない`);
+    return;
+  }
+
+  const manifestPath = path.join(prDirReal, "manifest.json");
+  const manifestStats = fs.lstatSync(manifestPath, { throwIfNoEntry: false });
+  if (manifestStats === undefined) {
+    console.log(`[demo-catalog] pr-${prNumber}/manifest.json が無いため何もしない`);
+    return;
+  }
+  if (!manifestStats.isFile()) {
+    fail(`manifest.json が通常ファイルではない（シンボリックリンクの可能性）: ${manifestPath}`);
+  }
+
+  const manifest = parseDemoManifest(JSON.parse(fs.readFileSync(manifestPath, "utf8")));
+  // Why not: prNumber の食い違いで落とさない（merge 後なので PR をやり直せない）。
+  // 実体がある pr-<番号>/ を読み込み元として採用し、食い違いは警告に留める。
+  // null は「録画時点で PR がまだ無い」通常経路なので警告もしない。
+  if (manifest.prNumber !== null && manifest.prNumber !== prNumber) {
+    console.warn(
+      `[demo-catalog] manifest.prNumber (${manifest.prNumber}) が指定された PR 番号 (${prNumber}) と食い違う。読み込み元の pr-${prNumber} を採用する`,
+    );
+  }
+
+  const featuresDir = path.join(assetsDirReal, FEATURES_DIR_NAME);
+  const existingFeaturesDirReal = realDirectoryWithin(assetsDirReal, featuresDir, "features/");
+  const plan = planCatalogUpdate({
+    manifest,
+    prNumber,
+    existingMetas: readExistingMetas(existingFeaturesDirReal),
+    // 昇格日は実行日。planCatalogUpdate を決定的に保つため、時計に触るのはここだけ。
+    promotedAt: new Date().toISOString().slice(0, 10),
+    assetsDir: assetsDirReal,
+  });
+
+  fs.mkdirSync(featuresDir, { recursive: true });
+  applyPlan(plan, {
+    prDirReal,
+    featuresDirReal: existingFeaturesDirReal ?? fs.realpathSync(featuresDir),
+  });
+
+  const features = [
+    ...new Set([
+      ...manifest.entries.map((entry) => entry.feature),
+      ...manifest.screenshots.map((screenshot) => screenshot.feature),
+    ]),
+  ].join(", ");
+  console.log(
+    `[demo-catalog] PR #${prNumber} のデモを features/ へ反映した: ${features || "なし"}`,
+  );
+}
+
+function parseArgs(argv: string[]): { assetsDir: string; prNumber: number } {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === undefined || value === undefined) break;
+    values.set(flag, value);
+  }
+
+  const assetsDir = values.get("--assets-dir");
+  const prNumber = Number(values.get("--pr"));
+  if (!assetsDir || !Number.isInteger(prNumber) || prNumber <= 0) {
+    fail("使い方: build-demo-catalog.ts --assets-dir <dir> --pr <番号>");
+  }
+  return { assetsDir: path.resolve(assetsDir), prNumber };
+}
+
+// テストから import したときは実行しない（CLI として起動されたときだけ動かす）。
+// Why not: import.meta / __filename との比較にしない。このファイルは node の型ストリップ（ESM）と
+// vitest の両方で読み込まれ、どちらかでしか存在しない識別子になるため。
+if (path.basename(process.argv[1] ?? "").startsWith("build-demo-catalog")) {
+  buildDemoCatalog(parseArgs(process.argv.slice(2)));
+}

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -37,8 +37,70 @@ done
 [ -n "$TITLE" ] || { echo "--title は必須" >&2; exit 1; }
 printf '%s' "$FEATURE" | grep -Eq '^[a-z0-9]+(-[a-z0-9]+)*$' || { echo "--feature は [a-z0-9-]+（連続/先頭末尾ハイフン不可）" >&2; exit 1; }
 
-# fail fast: ffmpeg (libx264)
+# fail fast: ffmpeg (libx264), python3 (attachment リネーム用)
 ffmpeg -hide_banner -encoders 2>/dev/null | grep -q libx264 || { echo "ffmpeg(libx264) が必要" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 が必要" >&2; exit 1; }
+
+# xcresulttool が書き出した attachment ファイル群を OUT_DIR へコピーするユーティリティ
+copy_shots_as_is() {
+  local src="$1" dst="$2" n=0 f
+  for f in "$src"/*.png "$src"/*.jpeg "$src"/*.jpg; do
+    [ -e "$f" ] || continue
+    cp "$f" "$dst/$(basename "$f")"
+    n=$((n+1))
+  done
+  echo "スクショ ${n}枚を $dst/ へ抽出（UUID名）"
+}
+
+# manifest.json の suggestedHumanReadableName（無ければ displayName / name）へリネームしてコピー。
+# manifest 不備・対象0件時は非正常終了する（呼び出し元で UUID 名コピーへフォールバック）
+copy_shots_with_manifest_names() {
+  python3 - "$1" "$2" <<'PY' || return 1
+import json, os, re, shutil, sys
+
+shots_dir, out_dir = sys.argv[1], sys.argv[2]
+try:
+    with open(os.path.join(shots_dir, "manifest.json")) as f:
+        data = json.load(f)
+except (OSError, ValueError):
+    sys.exit(1)
+# xcresulttool のトップレベルはテストごとのリスト。attachments を平坦化する
+if isinstance(data, list):
+    attachments = [a for item in data for a in item.get("attachments", [])]
+else:
+    attachments = data.get("attachments", [])
+
+valid_exts = {".png", ".jpg", ".jpeg"}
+used = set()
+count = 0
+for att in attachments:
+    exported = att.get("exportedFileName")
+    if not exported or not os.path.isfile(os.path.join(shots_dir, exported)):
+        continue
+    human_name = next(
+        (att[k] for k in ("suggestedHumanReadableName", "displayName", "name") if att.get(k)),
+        "",
+    )
+    safe_name = re.sub(r"[^A-Za-z0-9._-]", "-", os.path.basename(human_name))
+    stem, ext = os.path.splitext(safe_name)
+    ext = ext.lower()
+    if ext not in valid_exts:
+        payload_ext = os.path.splitext(exported)[1].lower()
+        ext = payload_ext if payload_ext in valid_exts else ".png"
+    base = f"{stem}{ext}" if stem else f"screenshot-{count + 1}{ext}"
+    target, seq = base, 1
+    while target in used:
+        target = f"{os.path.splitext(base)[0]}-{seq}{ext}"
+        seq += 1
+    used.add(target)
+    shutil.copyfile(os.path.join(shots_dir, exported), os.path.join(out_dir, target))
+    count += 1
+
+if count == 0:
+    sys.exit(1)
+print(count)
+PY
+}
 
 # シミュレータ選定: SIMULATOR_UDID 優先。無ければ起動済み、それも無ければ利用可能な iPhone を起動
 UDID="${SIMULATOR_UDID:-}"
@@ -93,17 +155,18 @@ ffmpeg -hide_banner -loglevel error -y -i "$RAW" -i "$WORK/palette.png" \
   -lavfi "setpts=PTS/$GIF_SPEED,fps=$GIF_FPS,scale=$GIF_WIDTH:-1:flags=lanczos[x];[x][1:v]paletteuse" \
   "$OUT_DIR/$FEATURE.gif"
 
-# スクショ抽出: テスト内の XCTAttachment(.keepAlways) を xcresult から書き出す
+# スクショ抽出: テスト内の XCTAttachment(.keepAlways) を xcresult から書き出す。
+# export attachments は UUID 名のファイルと manifest.json を出力するので、
+# manifest が読めれば XCTAttachment の name へリネームしてコピーする
 SHOTS_DIR="$WORK/shots"
 mkdir -p "$SHOTS_DIR"
 if xcrun xcresulttool export attachments --path "$XCRESULT" --output-path "$SHOTS_DIR" >/dev/null 2>&1; then
-  n=0
-  for f in "$SHOTS_DIR"/*.png "$SHOTS_DIR"/*.jpeg "$SHOTS_DIR"/*.jpg; do
-    [ -e "$f" ] || continue
-    cp "$f" "$OUT_DIR/$(basename "$f")"
-    n=$((n+1))
-  done
-  echo "スクショ ${n}枚を $OUT_DIR/ へ抽出"
+  if n=$(copy_shots_with_manifest_names "$SHOTS_DIR" "$OUT_DIR"); then
+    echo "スクショ ${n}枚を $OUT_DIR/ へ抽出（XCTAttachment の名前を使用）"
+  else
+    echo "manifest.json を読めないため UUID 名のままコピーします" >&2
+    copy_shots_as_is "$SHOTS_DIR" "$OUT_DIR"
+  fi
 else
   echo "xcresulttool export attachments が使えないためスクショ抽出をスキップ" >&2
 fi

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# E2Eデモ録画: DemoUITests をシミュレータで実行しながら録画し、
+# GIF（倍速・低解像度、PRインライン用）/ mp4（等倍、確認用）/ スクショPNG /
+# manifest.json / pr-body.md を demo-output/ に生成する。
+#
+# 使い方:
+#   scripts/record-demo.sh --feature <slug> --title "<1行説明>" [--test <メソッド名>] [--pr <PR番号>]
+#
+#   --feature  カタログ上の機能キー [a-z0-9-]+（例: playback-speed）
+#   --title    デモの1行説明（索引にそのまま出る）
+#   --test     実行するテストメソッド（省略時は DemoUITests 全体）
+#   --pr       PR番号。省略時は pr-body.md 内が <PR> のままになる（貼る時に置換）
+#
+# 生成物の push 先・PR への貼り方は docs/conventions/pr-assets.md を参照。
+# CI では動かさない（録画はローカルでオンデマンド）。
+set -euo pipefail
+
+SCHEME="Night-Core-Player"
+UITEST_TARGET="Night-Core-PlayerUITests"
+REPO="MizuRyu/NightCorePlayer"
+OUT_DIR="demo-output"
+GIF_SPEED=2      # GIFの倍速率
+GIF_WIDTH=320    # GIFの横幅(px)
+GIF_FPS=8
+
+FEATURE="" TITLE="" TEST="" PR_NUMBER="<PR>"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --feature) FEATURE="$2"; shift 2 ;;
+    --title)   TITLE="$2"; shift 2 ;;
+    --test)    TEST="$2"; shift 2 ;;
+    --pr)      PR_NUMBER="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+[ -n "$FEATURE" ] || { echo "--feature は必須" >&2; exit 1; }
+[ -n "$TITLE" ] || { echo "--title は必須" >&2; exit 1; }
+printf '%s' "$FEATURE" | grep -Eq '^[a-z0-9]+(-[a-z0-9]+)*$' || { echo "--feature は [a-z0-9-]+（連続/先頭末尾ハイフン不可）" >&2; exit 1; }
+
+# fail fast: ffmpeg (libx264)
+ffmpeg -hide_banner -encoders 2>/dev/null | grep -q libx264 || { echo "ffmpeg(libx264) が必要" >&2; exit 1; }
+
+# シミュレータ選定: SIMULATOR_UDID 優先。無ければ起動済み、それも無ければ利用可能な iPhone を起動
+UDID="${SIMULATOR_UDID:-}"
+if [ -z "$UDID" ]; then
+  UDID=$(xcrun simctl list devices booted -j | plutil -extract devices json -o - - 2>/dev/null \
+    | grep -oE '"udid" *: *"[A-F0-9-]+"' | head -1 | grep -oE '[A-F0-9-]{36}') || true
+fi
+if [ -z "$UDID" ]; then
+  UDID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | grep -oE '[A-F0-9-]{36}')
+fi
+[ -n "$UDID" ] || { echo "シミュレータが見つからない" >&2; exit 1; }
+xcrun simctl bootstatus "$UDID" -b >/dev/null
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$OUT_DIR"
+
+# 録画開始（バックグラウンド）→ テスト実行 → SIGINT で録画確定
+RAW="$WORK/raw.mov"
+xcrun simctl io "$UDID" recordVideo --codec h264 --force "$RAW" &
+REC_PID=$!
+sleep 1
+
+ONLY="$UITEST_TARGET"
+[ -n "$TEST" ] && ONLY="$UITEST_TARGET/DemoUITests/$TEST"
+XCRESULT="$WORK/demo.xcresult"
+set +e
+xcodebuild test \
+  -project "$SCHEME.xcodeproj" \
+  -scheme "$SCHEME" \
+  -destination "id=$UDID" \
+  -only-testing:"$ONLY" \
+  -resultBundlePath "$XCRESULT" \
+  -quiet
+TEST_STATUS=$?
+set -e
+kill -INT "$REC_PID" 2>/dev/null || true
+wait "$REC_PID" 2>/dev/null || true
+[ "$TEST_STATUS" -eq 0 ] || { echo "UIテストが失敗した（録画は $RAW に残っている）" >&2; exit "$TEST_STATUS"; }
+[ -s "$RAW" ] || { echo "録画ファイルが空" >&2; exit 1; }
+
+# mp4: 等倍・フル解像度（GitHubのファイルビューアで再生される）
+ffmpeg -hide_banner -loglevel error -y -i "$RAW" \
+  -c:v libx264 -pix_fmt yuv420p -movflags +faststart \
+  -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" \
+  "$OUT_DIR/$FEATURE.mp4"
+
+# GIF: 倍速・低解像度（PRインライン流し見用）。palette 2パスで劣化を抑える
+ffmpeg -hide_banner -loglevel error -y -i "$RAW" \
+  -vf "setpts=PTS/$GIF_SPEED,fps=$GIF_FPS,scale=$GIF_WIDTH:-1:flags=lanczos,palettegen" "$WORK/palette.png"
+ffmpeg -hide_banner -loglevel error -y -i "$RAW" -i "$WORK/palette.png" \
+  -lavfi "setpts=PTS/$GIF_SPEED,fps=$GIF_FPS,scale=$GIF_WIDTH:-1:flags=lanczos[x];[x][1:v]paletteuse" \
+  "$OUT_DIR/$FEATURE.gif"
+
+# スクショ抽出: テスト内の XCTAttachment(.keepAlways) を xcresult から書き出す
+SHOTS_DIR="$WORK/shots"
+mkdir -p "$SHOTS_DIR"
+if xcrun xcresulttool export attachments --path "$XCRESULT" --output-path "$SHOTS_DIR" >/dev/null 2>&1; then
+  n=0
+  for f in "$SHOTS_DIR"/*.png "$SHOTS_DIR"/*.jpeg "$SHOTS_DIR"/*.jpg; do
+    [ -e "$f" ] || continue
+    cp "$f" "$OUT_DIR/$(basename "$f")"
+    n=$((n+1))
+  done
+  echo "スクショ ${n}枚を $OUT_DIR/ へ抽出"
+else
+  echo "xcresulttool export attachments が使えないためスクショ抽出をスキップ" >&2
+fi
+
+# manifest.json（screenshots はスクショの画面キーが機械決定できないため空。手で追記する）
+cat > "$OUT_DIR/manifest.json" <<JSON
+{
+  "prNumber": ${PR_NUMBER/<PR>/0},
+  "entries": [
+    {
+      "feature": "$FEATURE",
+      "title": "$TITLE",
+      "roles": [],
+      "gif": "$FEATURE.gif",
+      "mp4": "$FEATURE.mp4"
+    }
+  ],
+  "screenshots": []
+}
+JSON
+
+# pr-body.md
+BASE="https://github.com/$REPO/blob/pr-assets/pr-$PR_NUMBER"
+cat > "$OUT_DIR/pr-body.md" <<MD
+![$TITLE]($BASE/$FEATURE.gif?raw=true)
+
+[▶ フル解像度の動画（mp4）]($BASE/$FEATURE.mp4?raw=true)
+MD
+
+echo "生成完了: $OUT_DIR/{$FEATURE.gif,$FEATURE.mp4,manifest.json,pr-body.md}"
+echo "次: 生成物を pr-assets ブランチの pr-$PR_NUMBER/ へ push し、pr-body.md を PR 本文へ貼る（docs/conventions/pr-assets.md）"


### PR DESCRIPTION
## 概要
leanbiz実運用のdemo-recording基盤（~/dotagents/templates/dev-setup）をSwift/iOSに移植。UIに変更があるPRへデモ動画・スクショを添付する運用を開始する。

## デモ

![検索から再生、倍速変更まで](https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-85/playback-speed.gif?raw=true)

[▶ フル解像度の動画（mp4）](https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-85/playback-speed.mp4?raw=true)

| 検索結果 | 倍速変更後 |
|---|---|
| ![検索結果](https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-85/03-search-results.png?raw=true) | ![倍速変更](https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-85/05-player-speed.png?raw=true) |

## 構成
- **pr-assets orphanブランチ**: `pr-<番号>/`（不変の証跡）+ `features/`（カタログ、merge時に自動更新）。作成・push済み
- **カタログ基盤**: `scripts/build-demo-catalog.ts` + `.github/workflows/demo-catalog.yml` + `docs/conventions/pr-assets.md`（テンプレ移植、REPO調整済み）
- **録画**: `scripts/record-demo.sh` — simctl recordVideo + xcodebuild test + ffmpeg で GIF（倍速320px）/mp4（等倍）/スクショPNG（XCTAttachment名でリネーム）/manifest.json/pr-body.md を生成。**このPRの上のデモがその実出力**
- **UITestターゲット** `Night-Core-PlayerUITests` 新設。通常の `make test` からは `-skip-testing` で除外
- **デモモード**: `-DEMO` 起動引数のときのみ composition root で MusicKitService を `DemoMusicKitService`（シード6曲・プレイリスト2件、Codable経由でSong生成）に差し替え。**シミュレータがFairPlay非対応でApple Music再生不可のための迂回**。通常起動は完全不変（`make test` green で確認）

## 検証
- `record-demo.sh` 全通し成功（録画→変換→抽出→manifest）
- 触ったファイル swiftlint 0違反 / 既存テストスイート green
- Actions枠が今月枯渇のため demo-catalog workflow の初回実行検証は9月（取りこぼしは workflow_dispatch で再実行可能）

## 残タスク（別PR/運用）
- PR #83（StoreKit 2）へのPro購入フローデモ追加（このブランチのデモモードに依存）
- Phase 2: 画面オーバーレイ（字幕・バナー）

closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
