### PR TITLE
feat: 残高枯渇シートとPro転換トリガー (#65)

### DIFF
--- a/Night-Core-Player/App.swift
+++ b/Night-Core-Player/App.swift
@@ -9,12 +9,13 @@ import SwiftUI
 
 @main
 struct NightcorePlayerApp: App {
-    @State private var nav = PlayerNavigator()
+    @State private var nav: PlayerNavigator
     @State private var playerVM: MusicPlayerViewModel
     @State private var settingsVM: SettingsViewModel
     @State private var searchVM: SearchViewModel
     @State private var playlistVM: PlaylistViewModel
     @State private var keyboard = KeyboardResponder()
+    @State private var allowanceSheetVM: AllowanceSheetViewModel
     private let playerService: MusicPlayerService
 
     init() {
@@ -23,6 +24,9 @@ struct NightcorePlayerApp: App {
             Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle")?.load()
             #endif
         #endif
+
+        let navigator = PlayerNavigator()
+        _nav = State(initialValue: navigator)
 
         // シミュレータは FairPlay 非対応のため、-DEMO 時のみ MusicKit カタログ系をスタブへ差し替える
         // （ensureAuth を no-op にすることで MusicAuthorization.request() も迂回する）
@@ -68,10 +72,17 @@ struct NightcorePlayerApp: App {
         _settingsVM = State(initialValue: SettingsViewModel(
             rateManager: rateManager,
             playerService: service,
-            proStore: proStoreService
+            proStore: proStoreService,
+            allowanceService: allowanceService
         ))
         _searchVM = State(initialValue: SearchViewModel(musicKitService: musicKitService))
         _playlistVM = State(initialValue: PlaylistViewModel(musicKitService: musicKitService))
+        _allowanceSheetVM = State(initialValue: AllowanceSheetViewModel(
+            allowanceEnforcer: allowanceEnforcer,
+            allowanceService: allowanceService,
+            proStoreService: proStoreService,
+            playerNavigator: navigator
+        ))
     }
 
     var body: some Scene {
@@ -101,6 +112,7 @@ struct NightcorePlayerApp: App {
             .environment(searchVM)
             .environment(playlistVM)
             .environment(keyboard)
+            .environment(allowanceSheetVM)
             .task {
                 await playerService.start()
             }

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetView.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct AllowanceSheetView: View {
+    let viewModel: AllowanceSheetViewModel
+
+    var body: some View {
+        VStack(spacing: 24) {
+            VStack(spacing: 8) {
+                Text(viewModel.showProPromptPitch ? "+30 Minutes Added" : "Today's Free Playback Time Is Used Up")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                Text("Normal-speed playback is still free")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            .multilineTextAlignment(.center)
+
+            if viewModel.showProPromptPitch {
+                Text("You've watched 5 ads. Go Pro and you'll never need to again.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundColor(.red)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(spacing: 12) {
+                Button {
+                    viewModel.watchAdForReward()
+                } label: {
+                    Text("Watch a Video for +30 Minutes")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.showProPromptPitch)
+                .accessibilityIdentifier("allowance_reward_button")
+
+                Button {
+                    viewModel.purchasePro()
+                } label: {
+                    if viewModel.isPurchasing {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("Go Unlimited with Pro (One-Time Purchase)")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.isPurchasing)
+                .accessibilityIdentifier("allowance_pro_button")
+
+                Button("Close") {
+                    viewModel.close()
+                }
+                .accessibilityIdentifier("allowance_close_button")
+            }
+        }
+        .padding()
+        .accessibilityIdentifier("allowance_sheet")
+    }
+}

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Combine
+import Observation
+import os
+
+@Observable
+@MainActor
+final class AllowanceSheetViewModel {
+    private(set) var isPresented = false
+    private(set) var isPurchasing = false
+    private(set) var showProPromptPitch = false
+    var errorMessage: String?
+
+    private let allowanceService: AllowanceService
+    private let proStoreService: ProStoreService
+    private let playerNavigator: PlayerNavigator
+    private let now: () -> Date
+    private let logger = Logger(subsystem: Constants.Logging.subsystem, category: "Allowance")
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(
+        allowanceEnforcer: AllowanceEnforcer,
+        allowanceService: AllowanceService,
+        proStoreService: ProStoreService,
+        playerNavigator: PlayerNavigator,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.allowanceService = allowanceService
+        self.proStoreService = proStoreService
+        self.playerNavigator = playerNavigator
+        self.now = now
+        // AllowanceEnforcerは@MainActor隔離のため、eventsの発行元は既にメインスレッド。receive(on:)によるhopは不要
+        allowanceEnforcer.events
+            .sink { [weak self] event in
+                guard case .stoppedAtSongEnd = event else { return }
+                self?.present()
+            }
+            .store(in: &cancellables)
+    }
+
+    func close() {
+        isPresented = false
+    }
+
+    // swiftlint:disable:next todo
+    // TODO: #62 リワード広告視聴に差し替える
+    func watchAdForReward() {
+        errorMessage = nil
+        do {
+            _ = try allowanceService.grantReward(now: now())
+        } catch {
+            errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
+            return
+        }
+
+        let shouldShowPrompt: Bool
+        do {
+            shouldShowPrompt = try allowanceService.shouldShowProPrompt(now: now())
+        } catch {
+            errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
+            return
+        }
+        guard shouldShowPrompt else {
+            close()
+            return
+        }
+
+        // markProPromptShownを先に実行し、保存に成功した場合のみ訴求を表示する。
+        // 保存失敗時に訴求だけ出すと「生涯1回」の保証が破れるため
+        do {
+            try allowanceService.markProPromptShown(now: now())
+            showProPromptPitch = true
+        } catch {
+            // リワード自体は成功しているためユーザー向けエラーにはしない
+            logger.error("markProPromptShown failed: \(error.localizedDescription)")
+            close()
+        }
+    }
+
+    func purchasePro() {
+        errorMessage = nil
+        Task {
+            guard !isPurchasing else { return }
+            isPurchasing = true
+            defer { isPurchasing = false }
+            do {
+                switch try await proStoreService.purchase() {
+                case .purchased:
+                    close()
+                case .cancelled, .pending:
+                    break
+                }
+            } catch {
+                errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func present() {
+        errorMessage = nil
+        showProPromptPitch = false
+        isPresented = true
+        // キューシートとの提示競合を避けるため排他にする
+        playerNavigator.isQueuePresented = false
+    }
+}

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -7,6 +7,7 @@ struct MainTabView: View {
     @Environment(MusicPlayerViewModel.self) private var playerVM
     @Environment(SettingsViewModel.self) private var settingsVM
     @Environment(KeyboardResponder.self) private var keyboard
+    @Environment(AllowanceSheetViewModel.self) private var allowanceSheetVM
 
     private let miniPlayerHeight: CGFloat = Constants.UI.FrameSize.miniMusicPlayerHeight
 
@@ -91,6 +92,12 @@ struct MainTabView: View {
                     .opacity(nav.isScrolling ? 0.3 : 1.0)
                     .animation(.easeInOut(duration: 0.2), value: nav.isScrolling)
             }
+        }
+        .sheet(isPresented: Binding(
+            get: { allowanceSheetVM.isPresented },
+            set: { isPresented in if !isPresented { allowanceSheetVM.close() } }
+        )) {
+            AllowanceSheetView(viewModel: allowanceSheetVM)
         }
         .enableInjection()
     }

--- a/Night-Core-Player/Features/Common/PlayerNavigator.swift
+++ b/Night-Core-Player/Features/Common/PlayerNavigator.swift
@@ -15,4 +15,7 @@ final class PlayerNavigator {
     var searchBarFocusRequestID: Int = 0
     var pendingArtist: Artist?
     var isScrolling: Bool = false
+
+    /// 再生キューシートの表示状態。AllowanceSheetの提示と排他にするためNavigatorで共有する
+    var isQueuePresented: Bool = false
 }

--- a/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
+++ b/Night-Core-Player/Features/MusicPlayer/MusicPlayerView.swift
@@ -52,7 +52,6 @@ struct MusicPlayerView: View {
     @Environment(PlayerNavigator.self) private var nav
     @Environment(MusicPlayerViewModel.self) private var vm
     @Environment(\.musicKitService) private var musicKitService
-    @State private var isQueuePresented = false
 
     init() {
         let clearImage = UIImage()
@@ -60,6 +59,7 @@ struct MusicPlayerView: View {
     }
 
     var body: some View {
+        @Bindable var nav = nav
         ZStack {
             VStack(spacing: 16) {
                 Text("Playing Now")
@@ -213,19 +213,19 @@ struct MusicPlayerView: View {
                 .frame(maxWidth: .infinity, minHeight: 30)
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    isQueuePresented = true
+                    nav.isQueuePresented = true
                 }
                 .gesture(
                     DragGesture(minimumDistance: 40)
                         .onEnded { value in
                             if value.translation.height < -40,
                                abs(value.translation.height) > abs(value.translation.width) {
-                                isQueuePresented = true
+                                nav.isQueuePresented = true
                             }
                         }
                 )
             }
-            .sheet(isPresented: $isQueuePresented) {
+            .sheet(isPresented: $nav.isQueuePresented) {
                 PlayingQueueView()
             }
             .onChange(of: nav.songs) { _, songs in

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -56,6 +56,8 @@ struct SettingsView: View {
                         .padding(.top, 8)
                 }
 
+                allowanceSection
+
                 proSection
 
                 Section {
@@ -108,6 +110,30 @@ struct SettingsView: View {
             Text(settingsVM.infoMessage ?? "")
         }
         .enableInjection()
+    }
+
+    // MARK: - Allowance
+
+    private var allowanceSection: some View {
+        Section {
+            HStack {
+                Text("Today's Remaining Playback Time")
+                    .font(.body)
+                    .foregroundColor(.primary)
+                Spacer()
+                Text(settingsVM.remainingTimeText)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 12)
+            .accessibilityIdentifier("allowance_remaining_row")
+            .listRowSeparator(.hidden)
+        } header: {
+            Text("Playback Time")
+                .font(.headline)
+                .foregroundColor(.primary)
+                .padding(.top, 8)
+        }
     }
 
     // MARK: - Pro

--- a/Night-Core-Player/Features/Settings/SettingsViewModel.swift
+++ b/Night-Core-Player/Features/Settings/SettingsViewModel.swift
@@ -12,19 +12,47 @@ final class SettingsViewModel {
     var isProEntitled: Bool { proStore?.isProEntitled ?? false }
     private(set) var proPriceText: String?
 
+    /// 今日の残り再生時間の表示テキスト。Pro > トライアル > 無料残高/枯渇の優先順位で判定する
+    var remainingTimeText: String {
+        guard let allowanceService else { return "" }
+        if isProEntitled {
+            return String(localized: "Unlimited")
+        }
+        do {
+            switch try allowanceService.entitlement(now: Date()) {
+            case .trial:
+                return String(localized: "Trial in Progress")
+            case .free(let remaining):
+                return Self.formattedRemaining(remaining)
+            case .exhausted:
+                return Self.formattedRemaining(0)
+            }
+        } catch {
+            return ""
+        }
+    }
+
     private let rateManager: PlaybackRateManager
     private let playerService: MusicPlayerService
     private let proStore: ProStoreService?
+    private let allowanceService: AllowanceService?
 
     init(
         rateManager: PlaybackRateManager,
         playerService: MusicPlayerService,
-        proStore: ProStoreService? = nil
+        proStore: ProStoreService? = nil,
+        allowanceService: AllowanceService? = nil
     ) {
         self.rateManager = rateManager
         self.playerService = playerService
         self.proStore = proStore
+        self.allowanceService = allowanceService
         self.defaultRate = rateManager.defaultRate
+    }
+
+    /// 時間単位に丸める。timeString(mm:ss固定)は再生時間表示（他機能）専用のため、60分超で「60:00」にならないここでは使わない
+    private static func formattedRemaining(_ seconds: TimeInterval) -> String {
+        Duration.seconds(max(0, seconds)).formatted(.units(allowed: [.hours, .minutes], width: .narrow))
     }
 
     func updateDefaultRate(to rate: Double) {

--- a/Night-Core-Player/Localizable.xcstrings
+++ b/Night-Core-Player/Localizable.xcstrings
@@ -496,7 +496,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "今日の無料再生時間を使い切りました"
+            "value": "本日の無料再生時間を使い切りました"
           }
         }
       }
@@ -506,7 +506,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "等速再生は引き続き無料です"
+            "value": "等倍再生は引き続き無料で再生頂けます。"
           }
         }
       }
@@ -516,7 +516,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "動画を見て+30分"
+            "value": "動画を視聴し再生時間を30分追加"
           }
         }
       }
@@ -526,7 +526,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pro（買い切り）で無制限"
+            "value": "Proプランで無制限再生"
           }
         }
       }
@@ -546,7 +546,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "広告を5回見ました。Proなら永久に不要です"
+            "value": "広告を5回視聴しました。本日の上限に達しました。Proなら永久再生可能◎"
           }
         }
       }
@@ -556,7 +556,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "今日の残り再生時間"
+            "value": "本日の残り再生時間"
           }
         }
       }
@@ -586,7 +586,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "+30分を追加しました"
+            "value": "再生時間を30分追加しました。"
           }
         }
       }

--- a/Night-Core-Player/Localizable.xcstrings
+++ b/Night-Core-Player/Localizable.xcstrings
@@ -490,6 +490,116 @@
           }
         }
       }
+    },
+    "Today's Free Playback Time Is Used Up": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日の無料再生時間を使い切りました"
+          }
+        }
+      }
+    },
+    "Normal-speed playback is still free": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等速再生は引き続き無料です"
+          }
+        }
+      }
+    },
+    "Watch a Video for +30 Minutes": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動画を見て+30分"
+          }
+        }
+      }
+    },
+    "Go Unlimited with Pro (One-Time Purchase)": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro（買い切り）で無制限"
+          }
+        }
+      }
+    },
+    "Close": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
+          }
+        }
+      }
+    },
+    "You've watched 5 ads. Go Pro and you'll never need to again.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "広告を5回見ました。Proなら永久に不要です"
+          }
+        }
+      }
+    },
+    "Today's Remaining Playback Time": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日の残り再生時間"
+          }
+        }
+      }
+    },
+    "Trial in Progress": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トライアル中"
+          }
+        }
+      }
+    },
+    "Unlimited": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無制限"
+          }
+        }
+      }
+    },
+    "+30 Minutes Added": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+30分を追加しました"
+          }
+        }
+      }
+    },
+    "Playback Time": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再生時間"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Night-Core-PlayerTests/Features/Allowance/AllowanceSheetViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Allowance/AllowanceSheetViewModelTests.swift
@@ -1,0 +1,297 @@
+import Testing
+import Foundation
+import Combine
+
+@testable import Night_Core_Player
+
+// MARK: - Stub
+
+@MainActor
+private final class AllowanceEnforcerStub: AllowanceEnforcer {
+    private let eventSubject = PassthroughSubject<AllowanceEvent, Never>()
+    var events: AnyPublisher<AllowanceEvent, Never> { eventSubject.eraseToAnyPublisher() }
+    var isExhausted = false
+
+    func tick(isPlaying: Bool, rate: Double, now: Date) {}
+    func shouldStopAtSongBoundary() -> Bool { false }
+    func markStoppedAtSongEnd() {}
+
+    func send(_ event: AllowanceEvent) {
+        eventSubject.send(event)
+    }
+}
+
+private struct SheetTestError: Error {}
+
+// MARK: - Tests
+
+@Suite("AllowanceSheetViewModel Tests")
+@MainActor
+struct AllowanceSheetViewModelTests {
+
+    // MARK: - Helpers
+
+    private static func setUp(
+        entitlement: PlaybackEntitlement = .exhausted,
+        shouldShowProPrompt: Bool = false,
+        purchaseResult: Result<ProPurchaseOutcome, Error> = .success(.purchased)
+    ) -> (
+        vm: AllowanceSheetViewModel,
+        enforcer: AllowanceEnforcerStub,
+        allowanceMock: AllowanceServiceMock,
+        storeMock: ProStoreServiceMock,
+        nav: PlayerNavigator
+    ) {
+        let enforcer = AllowanceEnforcerStub()
+        let allowanceMock = AllowanceServiceMock()
+        allowanceMock.entitlementResult = entitlement
+        allowanceMock.shouldShowProPromptResult = shouldShowProPrompt
+        let storeMock = ProStoreServiceMock()
+        storeMock.purchaseResult = purchaseResult
+        let nav = PlayerNavigator()
+        let vm = AllowanceSheetViewModel(
+            allowanceEnforcer: enforcer,
+            allowanceService: allowanceMock,
+            proStoreService: storeMock,
+            playerNavigator: nav
+        )
+        return (vm, enforcer, allowanceMock, storeMock, nav)
+    }
+
+    private static func waitUntil(
+        timeoutMilliseconds: Int = 1_000,
+        pollMilliseconds: Int = 10,
+        condition: @escaping @MainActor () -> Bool
+    ) async {
+        let attempts = max(1, timeoutMilliseconds / pollMilliseconds)
+        for _ in 0..<attempts {
+            if condition() { return }
+            try? await Task.sleep(nanoseconds: UInt64(pollMilliseconds) * 1_000_000)
+        }
+    }
+
+    // MARK: - Presentation
+
+    @Test(".stoppedAtSongEndの受信でシートが表示されること")
+    func stoppedAtSongEnd_presentsSheet() {
+        // Given
+        let (vm, enforcer, _, _, _) = Self.setUp()
+
+        // When
+        enforcer.send(.stoppedAtSongEnd)
+
+        // Then
+        #expect(vm.isPresented)
+    }
+
+    @Test(".exhaustedPendingSongEndではシートを表示しないこと")
+    func exhaustedPendingSongEnd_doesNotPresentSheet() {
+        // Given
+        let (vm, enforcer, _, _, _) = Self.setUp()
+
+        // When
+        enforcer.send(.exhaustedPendingSongEnd)
+
+        // Then
+        #expect(!vm.isPresented)
+    }
+
+    @Test(".stoppedAtSongEndの受信で再生キューシートが閉じること（提示の排他）")
+    func stoppedAtSongEnd_dismissesQueueSheet() {
+        // Given
+        let (vm, enforcer, _, _, nav) = Self.setUp()
+        _ = vm  // sink が [weak self] のため VM を保持する
+        nav.isQueuePresented = true
+
+        // When
+        enforcer.send(.stoppedAtSongEnd)
+
+        // Then
+        #expect(!nav.isQueuePresented, "AllowanceSheet提示時にキューシートは閉じる")
+    }
+
+    @Test("シート表示中に.stoppedAtSongEndを再受信すると、errorMessageとshowProPromptPitchがリセットされること")
+    func stoppedAtSongEnd_whileAlreadyPresented_resetsErrorAndPitch() {
+        // Given: Pro訴求を表示した状態
+        let (vm, enforcer, allowanceMock, _, _) = Self.setUp(shouldShowProPrompt: true)
+        enforcer.send(.stoppedAtSongEnd)
+        vm.watchAdForReward()
+        #expect(vm.showProPromptPitch)
+
+        // When: grantRewardが失敗する状態でもう一度リワードを叩き、errorMessageを立てておく
+        allowanceMock.grantRewardError = SheetTestError()
+        vm.watchAdForReward()
+        #expect(vm.errorMessage != nil)
+        #expect(vm.showProPromptPitch, "エラーで訴求フラグは変化しない")
+
+        // When: 別の枯渇で.stoppedAtSongEndを再受信（シートは表示中のまま再提示される）
+        enforcer.send(.stoppedAtSongEnd)
+
+        // Then
+        #expect(vm.errorMessage == nil)
+        #expect(!vm.showProPromptPitch)
+        #expect(vm.isPresented)
+    }
+
+    // MARK: - Reward
+
+    @Test("リワード視聴: grantRewardが呼ばれ、Pro訴求対象でなければシートが閉じること")
+    func watchAdForReward_withoutProPrompt_closesSheet() {
+        // Given
+        let (vm, enforcer, allowanceMock, _, _) = Self.setUp(shouldShowProPrompt: false)
+        enforcer.send(.stoppedAtSongEnd)
+        #expect(vm.isPresented)
+
+        // When
+        vm.watchAdForReward()
+
+        // Then
+        #expect(allowanceMock.grantRewardCallCount == 1, "grantRewardが1回呼ばれる")
+        #expect(!vm.isPresented, "訴求対象でなければ即座に閉じる")
+        #expect(!vm.showProPromptPitch)
+    }
+
+    @Test("リワード視聴: Pro訴求対象ならmarkProPromptShownを先に保存し、成功した場合のみシートを閉じずに訴求を表示すること")
+    func watchAdForReward_withProPrompt_savesFirstThenShowsPitch() {
+        // Given
+        let (vm, enforcer, allowanceMock, _, _) = Self.setUp(shouldShowProPrompt: true)
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.watchAdForReward()
+
+        // Then
+        #expect(vm.isPresented, "訴求を見せるためシートは開いたまま")
+        #expect(vm.showProPromptPitch, "保存に成功したので訴求が表示される")
+        #expect(allowanceMock.markProPromptShownCallCount == 1, "markProPromptShownは1回だけ呼ばれる")
+    }
+
+    @Test("リワード視聴: markProPromptShownが失敗したら訴求を表示せず、errorMessageにも出さないこと")
+    func watchAdForReward_markProPromptShownFails_doesNotShowPitchOrUserError() {
+        // Given: 保存自体が失敗する状態
+        let (vm, enforcer, allowanceMock, _, _) = Self.setUp(shouldShowProPrompt: true)
+        allowanceMock.markProPromptShownError = SheetTestError()
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.watchAdForReward()
+
+        // Then: リワード自体は成功しているため、ユーザー向けエラーは出さず訴求も出さない
+        #expect(!vm.showProPromptPitch, "保存失敗時に「生涯1回」の保証を破らないよう訴求を出さない")
+        #expect(vm.errorMessage == nil, "保存失敗はログのみでユーザー向けエラーにしない")
+    }
+
+    @Test("Pro訴求は生涯1回だけ表示される（2回目のリワードでは再表示されない）")
+    func watchAdForReward_calledTwice_showsProPromptOnlyOnce() {
+        // Given: 1回目は訴求条件を満たす
+        let (vm, enforcer, allowanceMock, _, _) = Self.setUp(shouldShowProPrompt: true)
+        enforcer.send(.stoppedAtSongEnd)
+        vm.watchAdForReward()
+        #expect(vm.showProPromptPitch)
+        #expect(allowanceMock.markProPromptShownCallCount == 1)
+
+        // When: シートを閉じて再度枯渇し、もう一度リワードを視聴する
+        vm.close()
+        enforcer.send(.stoppedAtSongEnd)
+        #expect(!vm.showProPromptPitch, "再提示時にリセットされる")
+
+        vm.watchAdForReward()
+
+        // Then: markProPromptShownは増えず、訴求も再表示されない
+        #expect(!vm.showProPromptPitch, "生涯1回の訴求は2回目に表示されない")
+        #expect(allowanceMock.markProPromptShownCallCount == 1, "markProPromptShownは生涯1回のまま")
+        #expect(!vm.isPresented, "2回目は訴求対象外の通常フローとして閉じる")
+    }
+
+    @Test("リワード視聴: grantRewardがエラーならerrorMessageが設定されること")
+    func watchAdForReward_grantRewardThrows_setsErrorMessage() {
+        // Given
+        let (vm, enforcer, allowanceMock, _, _) = Self.setUp()
+        allowanceMock.grantRewardError = SheetTestError()
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.watchAdForReward()
+
+        // Then
+        #expect(vm.errorMessage != nil)
+        #expect(vm.isPresented, "エラー時はシートを閉じない")
+    }
+
+    // MARK: - Purchase
+
+    @Test("Pro購入: 購入成功でシートが閉じること")
+    func purchasePro_success_closesSheet() async throws {
+        // Given
+        let (vm, enforcer, _, storeMock, _) = Self.setUp(purchaseResult: .success(.purchased))
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.purchasePro()
+        await Self.waitUntil { storeMock.purchaseCallCount == 1 }
+
+        // Then
+        await Self.waitUntil { !vm.isPresented }
+        #expect(!vm.isPresented)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("Pro購入: キャンセルではシートを閉じないこと")
+    func purchasePro_cancelled_keepsSheetOpen() async throws {
+        // Given
+        let (vm, enforcer, _, storeMock, _) = Self.setUp(purchaseResult: .success(.cancelled))
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.purchasePro()
+        await Self.waitUntil { storeMock.purchaseCallCount == 1 }
+
+        // Then
+        #expect(vm.isPresented)
+    }
+
+    @Test("Pro購入: pendingではシートを閉じないこと")
+    func purchasePro_pending_keepsSheetOpen() async throws {
+        // Given
+        let (vm, enforcer, _, storeMock, _) = Self.setUp(purchaseResult: .success(.pending))
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.purchasePro()
+        await Self.waitUntil { storeMock.purchaseCallCount == 1 }
+
+        // Then
+        #expect(vm.isPresented)
+    }
+
+    @Test("Pro購入: エラーがシート内のerrorMessageに反映されること")
+    func purchasePro_throws_setsErrorMessage() async throws {
+        // Given
+        let (vm, enforcer, _, _, _) = Self.setUp(purchaseResult: .failure(SheetTestError()))
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.purchasePro()
+        await Self.waitUntil { vm.errorMessage != nil }
+
+        // Then
+        #expect(vm.errorMessage != nil)
+        #expect(vm.isPresented, "エラー時はシートを閉じない")
+    }
+
+    // MARK: - Close
+
+    @Test("閉じるボタン相当のclose()呼び出しでシートが閉じること")
+    func close_dismissesSheet() {
+        // Given
+        let (vm, enforcer, _, _, _) = Self.setUp()
+        enforcer.send(.stoppedAtSongEnd)
+        #expect(vm.isPresented)
+
+        // When
+        vm.close()
+
+        // Then
+        #expect(!vm.isPresented)
+    }
+}

--- a/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 
 @testable import Night_Core_Player
 
@@ -35,7 +36,10 @@ struct SettingsViewModelTests {
         }
     }
 
-    private static func setUp(proStore: ProStoreService? = nil) -> (
+    private static func setUp(
+        proStore: ProStoreService? = nil,
+        allowanceService: AllowanceService? = nil
+    ) -> (
         vm: SettingsViewModel,
         rateMock: PlaybackRateManagerMock,
         svcMock: MusicPlayerServiceMock
@@ -45,7 +49,8 @@ struct SettingsViewModelTests {
         let vm = SettingsViewModel(
             rateManager: rateMock,
             playerService: svcMock,
-            proStore: proStore
+            proStore: proStore,
+            allowanceService: allowanceService
         )
         return (vm, rateMock, svcMock)
     }
@@ -194,5 +199,77 @@ struct SettingsViewModelTests {
         #expect(vm.proPriceText == nil, "価格は読み込まれない")
         #expect(vm.errorMessage == nil)
         #expect(vm.infoMessage == nil)
+    }
+
+    // MARK: - Allowance
+
+    @Test("remainingTimeText: Pro権限があれば無制限と表示されること")
+    func remainingTimeText_proEntitled_showsUnlimited() {
+        // Given
+        let storeMock = ProStoreServiceMock()
+        storeMock.entitledResult = true
+        let allowanceMock = AllowanceServiceMock()
+        allowanceMock.entitlementResult = .free(remaining: 0)
+        let (vm, _, _) = SettingsViewModelTests.setUp(proStore: storeMock, allowanceService: allowanceMock)
+
+        // Then
+        #expect(vm.remainingTimeText == String(localized: "Unlimited"))
+    }
+
+    @Test("remainingTimeText: トライアル中はTrial in Progressと表示されること")
+    func remainingTimeText_trial_showsTrialInProgress() {
+        // Given
+        let allowanceMock = AllowanceServiceMock()
+        allowanceMock.entitlementResult = .trial(endsAt: Date().addingTimeInterval(86400))
+        let (vm, _, _) = SettingsViewModelTests.setUp(allowanceService: allowanceMock)
+
+        // Then
+        #expect(vm.remainingTimeText == String(localized: "Trial in Progress"))
+    }
+
+    @Test("remainingTimeText: 残高3600秒は「60:00」ではなく時間単位で表示されること")
+    func remainingTimeText_free3600Seconds_doesNotShowSixtyMinutes() {
+        // Given
+        let allowanceMock = AllowanceServiceMock()
+        allowanceMock.entitlementResult = .free(remaining: 3600)
+        let (vm, _, _) = SettingsViewModelTests.setUp(allowanceService: allowanceMock)
+        let expected = Duration.seconds(3600).formatted(.units(allowed: [.hours, .minutes], width: .narrow))
+
+        // Then
+        #expect(vm.remainingTimeText == expected)
+        #expect(!vm.remainingTimeText.contains("60:"), "60分表記のバグが再発していないこと")
+    }
+
+    @Test("remainingTimeText: 残高5400秒は時間+分で表示されること")
+    func remainingTimeText_free5400Seconds_showsHoursAndMinutes() {
+        // Given
+        let allowanceMock = AllowanceServiceMock()
+        allowanceMock.entitlementResult = .free(remaining: 5400)
+        let (vm, _, _) = SettingsViewModelTests.setUp(allowanceService: allowanceMock)
+        let expected = Duration.seconds(5400).formatted(.units(allowed: [.hours, .minutes], width: .narrow))
+
+        // Then
+        #expect(vm.remainingTimeText == expected)
+    }
+
+    @Test("remainingTimeText: 枯渇時は0表示になること")
+    func remainingTimeText_exhausted_showsZero() {
+        // Given
+        let allowanceMock = AllowanceServiceMock()
+        allowanceMock.entitlementResult = .exhausted
+        let (vm, _, _) = SettingsViewModelTests.setUp(allowanceService: allowanceMock)
+        let expected = Duration.seconds(0).formatted(.units(allowed: [.hours, .minutes], width: .narrow))
+
+        // Then
+        #expect(vm.remainingTimeText == expected)
+    }
+
+    @Test("remainingTimeText: allowanceServiceがnilなら空文字になること")
+    func remainingTimeText_noAllowanceService_isEmpty() {
+        // Given
+        let (vm, _, _) = SettingsViewModelTests.setUp()
+
+        // Then
+        #expect(vm.remainingTimeText.isEmpty)
     }
 }

--- a/Night-Core-PlayerTests/Mock/AllowanceServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/AllowanceServiceMock.swift
@@ -4,8 +4,16 @@ import Foundation
 @MainActor
 final class AllowanceServiceMock: AllowanceService {
     var entitlementResult: PlaybackEntitlement = .free(remaining: Constants.Allowance.dailyFreeSeconds)
+    var grantRewardError: Error?
+    var shouldShowProPromptResult = false
+    var markProPromptShownError: Error?
 
     private(set) var consumeArgs: [(seconds: TimeInterval, now: Date)] = []
+    private(set) var grantRewardCallCount = 0
+    private(set) var markProPromptShownCallCount = 0
+
+    /// markProPromptShownが（エラーなく）呼ばれた後はshouldShowProPromptがfalseになる。生涯1回の実挙動を模す
+    private var proPromptShown = false
 
     func entitlement(now: Date) throws -> PlaybackEntitlement {
         entitlementResult
@@ -15,9 +23,23 @@ final class AllowanceServiceMock: AllowanceService {
         consumeArgs.append((seconds, now))
     }
 
-    func grantReward(now: Date) throws -> TimeInterval { 0 }
+    func grantReward(now: Date) throws -> TimeInterval {
+        grantRewardCallCount += 1
+        if let grantRewardError {
+            throw grantRewardError
+        }
+        return 0
+    }
 
-    func shouldShowProPrompt(now: Date) throws -> Bool { false }
+    func shouldShowProPrompt(now: Date) throws -> Bool {
+        shouldShowProPromptResult && !proPromptShown
+    }
 
-    func markProPromptShown(now: Date) throws {}
+    func markProPromptShown(now: Date) throws {
+        markProPromptShownCallCount += 1
+        if let markProPromptShownError {
+            throw markProPromptShownError
+        }
+        proPromptShown = true
+    }
 }


### PR DESCRIPTION
## 概要
残高枯渇イベントをUIへ配線し、収益化ファネルの最後のピースを埋める。

- `AllowanceSheetView/ViewModel`（新規）: 曲境界停止（`.stoppedAtSongEnd`）で全タブ上にシート表示。「動画を見て+30分」（現状は grantReward 直呼びプレースホルダ、#62で広告視聴に差し替え）／「Proで無制限」（購入フロー）／「閉じる」
- Pro転換トリガー: リワード後に `shouldShowProPrompt()` が true なら訴求を表示し `markProPromptShown()`（**永続化成功時のみ表示** = 生涯1回を保証）
- 設定画面に「今日の残り再生時間」行（Pro=無制限 / トライアル中 / 残り時間。60分超も正しく表示）
- キューシートとの提示競合を排他化（`isQueuePresented` を PlayerNavigator へ移動）

## キャプチャ

| 設定画面の残り時間表示 |
|---|
| <img src="https://github.com/MizuRyu/NightCorePlayer/blob/pr-assets/pr-86/settings-allowance.png?raw=true" width="320" /> |

枯渇シート自体のデモ録画は、デモモードに枯渇状態を注入する仕組み（follow-up）を入れてから追加する。

## レビューサイクル
impl-sonnet実装（opencodeはprovider障害のため代替）→ opus敵対的レビュー（high2・mid6・low6）→ impl-sonnet修正 → Fable検証。
主な修正: 訴求「生涯1回」が保存失敗時に破れる経路／残り時間が「60:00」と表示される整形バグ／シート提示競合／errorMessageリセット漏れ／テスト強化（生涯1回を状態付きMockで実証）

## 検証
- 全テストスイート green（AllowanceSheetViewModelTests 12本 / SettingsViewModelTests拡充）
- 触ったファイル swiftlint 0違反

## follow-up（別issue化予定）
- ユニットテストが AppDataStore.shared に日付固定データを残し、シミュレータの残高状態がテスト実行履歴に依存する（デモ決定性・実機確認の再現性に影響）
- リワード付与後に再生・倍速が自動復帰しない割り切りの再検討

closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
