### PR TITLE
feat: ATT対応とPrivacyInfo更新 (#63)

### DIFF
--- a/Night-Core-Player.xcodeproj/project.pbxproj
+++ b/Night-Core-Player.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Night-Core-Player/Info.plist";
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "ライブラリにアクセスしてプレイリストを表示";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "Used to make ads more relevant to you. Ads are still shown if you don't allow tracking.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = "(audio)";
@@ -553,6 +554,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Night-Core-Player/Info.plist";
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "ライブラリにアクセスしてプレイリストを表示";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "Used to make ads more relevant to you. Ads are still shown if you don't allow tracking.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = "(audio)";

--- a/Night-Core-Player/App.swift
+++ b/Night-Core-Player/App.swift
@@ -18,6 +18,9 @@ struct NightcorePlayerApp: App {
     @State private var keyboard = KeyboardResponder()
     @State private var allowanceSheetVM: AllowanceSheetViewModel
     private let playerService: MusicPlayerService
+    private let isDemo: Bool
+    private let trackingService: TrackingAuthorizationService
+    private let rewardedAdService: RewardedAdService?
 
     init() {
         #if DEBUG
@@ -30,6 +33,8 @@ struct NightcorePlayerApp: App {
         _nav = State(initialValue: navigator)
 
         let isDemo = ProcessInfo.processInfo.arguments.contains("-DEMO")
+        self.isDemo = isDemo
+        trackingService = TrackingAuthorizationServiceImpl()
 
         // シミュレータは FairPlay 非対応のため、-DEMO 時のみ MusicKit カタログ系をスタブへ差し替える
         // （ensureAuth を no-op にすることで MusicAuthorization.request() も迂回する）
@@ -40,18 +45,15 @@ struct NightcorePlayerApp: App {
             musicKitService = MusicKitServiceImpl()
         }
 
-        // デモ録画に広告が出ると困るため、-DEMO 時は初期化しない
+        // デモ録画に広告が出ると困るため、-DEMO 時はATT要求・SDK初期化とも行わない
+        // 実際の要求とSDK初期化はメインUI表示後（mainRootView の .task）にまとめて行う
         let rewardedAdService: RewardedAdService?
         if isDemo {
             rewardedAdService = nil
         } else {
-            let adService = RewardedAdServiceImpl()
-            rewardedAdService = adService
-            Task {
-                await MobileAds.shared.start()
-                await adService.preload()
-            }
+            rewardedAdService = RewardedAdServiceImpl()
         }
+        self.rewardedAdService = rewardedAdService
 
         let context = AppDataStore.shared.container.mainContext
         let playerStateRepo = PlayerStateRepository(context: context)
@@ -133,5 +135,17 @@ struct NightcorePlayerApp: App {
             .task {
                 await playerService.start()
             }
+            .task {
+                await initializeAdsIfNeeded()
+            }
+    }
+
+    /// ATT許可要求 → 完了待ち → SDK初期化 → 広告preload の順で行う。
+    /// IDFAゼロ化を避けるため、要求前にSDKを初期化しない
+    private func initializeAdsIfNeeded() async {
+        guard !isDemo, let rewardedAdService else { return }
+        await trackingService.requestIfNeeded()
+        await MobileAds.shared.start()
+        await rewardedAdService.preload()
     }
 }

--- a/Night-Core-Player/InfoPlist.xcstrings
+++ b/Night-Core-Player/InfoPlist.xcstrings
@@ -1,0 +1,17 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "NSUserTrackingUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "広告の関連性を高めるために使用します。許可しない場合も広告は表示されます。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Night-Core-Player/PrivacyInfo.xcprivacy
+++ b/Night-Core-Player/PrivacyInfo.xcprivacy
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyTracking</key>
-	<false/>
+	<true/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
@@ -30,6 +30,50 @@
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<!-- #63: AdMob導入に伴い追加。Linked/Tracking/Purposesは導入済みGoogleMobileAds SDK 12.14.0が
+		     自身のPrivacyInfo.xcprivacyで宣言している値に合わせている -->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeThirdPartyAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeAdvertisingData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeThirdPartyAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeThirdPartyAdvertising</string>
 			</array>
 		</dict>
 	</array>

--- a/Night-Core-Player/Services/TrackingAuthorizationService.swift
+++ b/Night-Core-Player/Services/TrackingAuthorizationService.swift
@@ -1,0 +1,34 @@
+//
+//  TrackingAuthorizationService.swift
+//  Night-Core-Player
+//
+
+import Foundation
+import AppTrackingTransparency
+import os
+
+// MARK: - Protocol
+
+@MainActor
+protocol TrackingAuthorizationService: Sendable {
+    var status: ATTrackingManager.AuthorizationStatus { get }
+    /// .notDetermined の場合のみシステムダイアログを表示し、完了まで待つ
+    func requestIfNeeded() async
+}
+
+// MARK: - Impl
+
+@MainActor
+final class TrackingAuthorizationServiceImpl: TrackingAuthorizationService {
+    private let logger = Logger(subsystem: Constants.Logging.subsystem, category: "Tracking")
+
+    var status: ATTrackingManager.AuthorizationStatus {
+        ATTrackingManager.trackingAuthorizationStatus
+    }
+
+    func requestIfNeeded() async {
+        guard status == .notDetermined else { return }
+        let result = await ATTrackingManager.requestTrackingAuthorization()
+        logger.info("ATT authorization requested, result: \(String(describing: result))")
+    }
+}

--- a/Night-Core-PlayerTests/Mock/TrackingAuthorizationServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/TrackingAuthorizationServiceMock.swift
@@ -1,0 +1,19 @@
+import Foundation
+import AppTrackingTransparency
+@testable import Night_Core_Player
+
+@MainActor
+final class TrackingAuthorizationServiceMock: TrackingAuthorizationService {
+    var status: ATTrackingManager.AuthorizationStatus = .notDetermined
+
+    private(set) var requestIfNeededCallCount = 0
+
+    /// ATTrackingManager.requestTrackingAuthorization() 後にOSが遷移させる状態を模す
+    var statusAfterRequest: ATTrackingManager.AuthorizationStatus = .authorized
+
+    func requestIfNeeded() async {
+        guard status == .notDetermined else { return }
+        requestIfNeededCallCount += 1
+        status = statusAfterRequest
+    }
+}

--- a/Night-Core-PlayerTests/Services/TrackingAuthorizationServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/TrackingAuthorizationServiceTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import AppTrackingTransparency
+@testable import Night_Core_Player
+
+@Suite("TrackingAuthorizationService Tests")
+@MainActor
+struct TrackingAuthorizationServiceTests {
+
+    @Test("requestIfNeeded: notDetermined時は要求してauthorizedへ遷移すること")
+    func requestIfNeeded_notDetermined_requests() async {
+        let mock = TrackingAuthorizationServiceMock()
+        mock.status = .notDetermined
+
+        await mock.requestIfNeeded()
+
+        #expect(mock.requestIfNeededCallCount == 1, "notDetermined時は要求が1回行われること")
+        #expect(mock.status == .authorized, "要求後はOSが返した状態に遷移すること")
+    }
+
+    @Test("requestIfNeeded: authorized済みの場合は再要求しないこと")
+    func requestIfNeeded_authorized_doesNotRequest() async {
+        let mock = TrackingAuthorizationServiceMock()
+        mock.status = .authorized
+
+        await mock.requestIfNeeded()
+
+        #expect(mock.requestIfNeededCallCount == 0, "既に確定済みの状態では要求しないこと")
+    }
+
+    @Test("requestIfNeeded: denied済みの場合は再要求しないこと")
+    func requestIfNeeded_denied_doesNotRequest() async {
+        let mock = TrackingAuthorizationServiceMock()
+        mock.status = .denied
+
+        await mock.requestIfNeeded()
+
+        #expect(mock.requestIfNeededCallCount == 0, "拒否済みの状態では要求しないこと")
+    }
+
+    @Test("requestIfNeeded: restricted済みの場合は再要求しないこと")
+    func requestIfNeeded_restricted_doesNotRequest() async {
+        let mock = TrackingAuthorizationServiceMock()
+        mock.status = .restricted
+
+        await mock.requestIfNeeded()
+
+        #expect(mock.requestIfNeededCallCount == 0, "制限済みの状態では要求しないこと")
+    }
+}


### PR DESCRIPTION
## 概要
#63 のコード側。**PR #90 の上にスタック**（base = feature/62-admob-rewarded。#90マージ後にbaseをmainへ）。文書側は #89 で別途対応済み。

## ATT（AppTrackingTransparency）
- `Services/TrackingAuthorizationService.swift`（新規）: `.notDetermined` のときだけ許可を要求し、完了まで await
- **要求順序**: ATT要求 → 完了待ち → `MobileAds.shared.start()` → 広告preload。公式ガイドどおり、要求前はIDFAがゼロ化され広告収益が落ちるため順序が重要
- **タイミング**: `init()` ではインスタンス生成のみとし、実際の非同期処理は `.task` へ移した。init内だとビュー表示前に発火し「起動直後の唐突なダイアログ」になるため
- `INFOPLIST_KEY_NSUserTrackingUsageDescription` をDebug/Release両方に追加、`InfoPlist.xcstrings` でja翻訳
- **`-DEMO` 時はATT要求・SDK初期化・preloadのすべてをスキップ**（デモ録画が壊れない）

## PrivacyInfo.xcprivacy（全面見直し）
現状は `NSPrivacyTracking=false`・広告データ未申告で、AdMob導入後の実態と乖離していた。

- `NSPrivacyTracking` → **true**
- 収集データ型に **DeviceID / AdvertisingData / ProductInteraction** を追加（CrashData・PerformanceDataは維持）

**根拠の取り方**: 公式ドキュメントのAI要約は信頼性が低いと判断し、**実際に導入済みのGoogleMobileAds SDK 12.14.0がバンドルしている `PrivacyInfo.xcprivacy` を直接読んで**、その宣言（Linked/Tracking/Purposes）をそのまま転記した。

## 判断が分かれた点
- **`NSPrivacyTrackingDomains` は空配列のまま**にした。Apple公式によれば依存関係は「TrackingDomainsを使うにはTracking=trueが前提」の一方向のみで、逆（true なら1件以上必須）ではない。SDK自身のマニフェストにもドメイン宣言がなく、公式にAdMob用の確定リストが見当たらなかったため、**推測でドメインを列挙しなかった**
- `NSPrivacyAccessedAPITypes` はSDK側が `SystemBootTime`/`DiskSpace` を自身の分として宣言済みで、Appleがビルド時にフレームワーク単位のマニフェストを自動合算するため、アプリ側で重複追加していない
- `PurchaseHistory` は `ProStoreService` が標準StoreKit 2 APIのみを使い独自の購入履歴保存をしていないため申告不要と判断

## SKAdNetworkItems
#90 で既に追加済みのため、rebase時の競合はコメント1行のみ（ID 50件は完全一致）を解消。**50件・重複なし**を検証済み。

## 検証
- 全テストスイート green（`TrackingAuthorizationServiceTests` 4ケース追加。ATTはシステムダイアログのためprotocol越しのモックで分岐のみ検証）
- 触ったファイル swiftlint 0違反
- `plutil -lint` Info.plist / PrivacyInfo.xcprivacy ともにOK

## 残作業（ユーザー作業・別issue）
- **App Store Connect のプライバシーラベル更新**（AdMob基準: Identifiers / Usage Data / Diagnostics、トラッキング用途あり）
- UMP（EEA向け同意管理）: 依存は解決済みだが未実装。EU配信を除外する方針のため優先度低

refs #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)