### PR TITLE
chore(ci): CIをmainマージ時のみ+self-hosted runner対応に (#58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
 name: CI
 
+# iOS ビルドは重いので PR では回さず、main マージ時のみ実行する(#58)。
+# マージ前の検証はローカルの `make check` / `make test` と lefthook が担う。
+#
+# 実行先はリポジトリ変数 CI_RUNNER で切り替える(leanbiz 方式):
+#   未設定                  → macos-15(GitHub ホスト。Xcode は runner 同梱の既定)
+#   ["self-hosted","macOS"] → 手元の Mac(xcodes 管理の Xcode をそのまま使う)
+#
+#   gh variable set CI_RUNNER --body '["self-hosted","macOS"]'   # 手元へ寄せる
+#   gh variable delete CI_RUNNER                                  # GitHub ホストへ戻す
 on:
   push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,10 +24,8 @@ permissions:
 jobs:
   test:
     name: Build & Test
-    runs-on: macos-15
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '"macos-15"') }}
     timeout-minutes: 30
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 概要

iOS ビルドが重いため、CI を PR 単位では回さず main マージ時のみ実行するよう変更する。あわせて実行先をリポジトリ変数 `CI_RUNNER` で GitHub ホスト / self-hosted(手元 Mac) に切り替えられるようにする(leanbiz 方式)。

## 変更内容

- トリガーを `push: [main]` + `workflow_dispatch` のみに変更
- `DEVELOPER_DIR` の Xcode 16.4 固定を撤去(#58 の原因。self-hosted では手元の xcodes 管理に追従)
- `runs-on` を `fromJSON(vars.CI_RUNNER || '"macos-15"')` に変更

## マージ前検証の代替

- ローカルの `make check`(build + swiftlint + swiftformat --lint) と `make test`
- lefthook pre-commit(swiftlint --strict / gitleaks / conventional-commit)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoTgSCyVLzNfESbTQZMoeP