### PR TITLE
feat: AdMob本番IDを設定 (#62)

### DIFF
--- a/Night-Core-Player/Core/BusinessConstants.swift
+++ b/Night-Core-Player/Core/BusinessConstants.swift
@@ -52,11 +52,11 @@ public enum Constants {
     }
 
     public enum Ads {
-        // 本番リワードユニットID未発行のためテストIDを暫定使用。AdMobで本番ユニットIDを発行したら、
-        // このIDに差し替えるだけで本番切り替えが完了する形にしてある
-        #if !DEBUG
-        #warning("#62 本番リワードユニットID未設定")
-        #endif
+        // Debug は Google 公式のテストユニットID、Release は本番ユニットID(rewarded_balance)
+        #if DEBUG
         public static let rewardedUnitID: String = "ca-app-pub-3940256099942544/1712485313"
+        #else
+        public static let rewardedUnitID: String = "ca-app-pub-4210364120390329/6068775358"
+        #endif
     }
 }

--- a/Night-Core-Player/Info.plist
+++ b/Night-Core-Player/Info.plist
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- #62: AdMobテスト用アプリID。本番アプリID発行後に差し替えること -->
+	<!-- #62: 本番アプリID。テストは BusinessConstants.Ads のユニットID側で切り替える -->
 	<key>GADApplicationIdentifier</key>
-	<string>ca-app-pub-3940256099942544~1458002511</string>
+	<string>ca-app-pub-4210364120390329~8520680894</string>
 	<!-- #62: Google AdMob公式(https://developers.google.com/admob/ios/quick-start)掲載のSKAdNetworkIdentifier一覧。全50件 -->
 	<key>SKAdNetworkItems</key>
 	<array>


### PR DESCRIPTION
## 概要

AdMob で発行した本番 ID をコードに反映する。Debug はテスト ID のまま、Release のみ本番 ID を使う。

## 変更内容

- `Info.plist`: `GADApplicationIdentifier` を本番アプリ ID `ca-app-pub-4210364120390329~8520680894` に差し替え(アプリ ID は全ビルド共通が Google 推奨)
- `BusinessConstants.Ads.rewardedUnitID`: `#if DEBUG` で分岐。Debug = Google 公式テスト ID / Release = 本番ユニット `rewarded_balance`

## 検証

- Debug / Release ビルド成功
- Release 生成物の Info.plist に本番 App ID が入ることを plutil で確認
- ユニットテスト全通過、SwiftLint 既存 warning のみ

Refs #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoTgSCyVLzNfESbTQZMoeP