### PR TITLE
fix: リワード後の再生自動復帰・テストin-memory化・IDFA回答修正 (#87 #77)

### DIFF
--- a/Night-Core-Player/App.swift
+++ b/Night-Core-Player/App.swift
@@ -100,7 +100,8 @@ struct NightcorePlayerApp: App {
             allowanceService: allowanceService,
             proStoreService: proStoreService,
             playerNavigator: navigator,
-            rewardedAdService: rewardedAdService
+            rewardedAdService: rewardedAdService,
+            musicPlayerService: service
         ))
     }
 

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
@@ -16,6 +16,7 @@ final class AllowanceSheetViewModel {
     private let proStoreService: ProStoreService
     private let rewardedAdService: RewardedAdService?
     private let playerNavigator: PlayerNavigator
+    private let musicPlayerService: MusicPlayerService?
     private let now: () -> Date
     private let logger = Logger(subsystem: Constants.Logging.subsystem, category: "Allowance")
     private var cancellables: Set<AnyCancellable> = []
@@ -26,12 +27,14 @@ final class AllowanceSheetViewModel {
         proStoreService: ProStoreService,
         playerNavigator: PlayerNavigator,
         rewardedAdService: RewardedAdService? = nil,
+        musicPlayerService: MusicPlayerService? = nil,
         now: @escaping () -> Date = Date.init
     ) {
         self.allowanceService = allowanceService
         self.proStoreService = proStoreService
         self.rewardedAdService = rewardedAdService
         self.playerNavigator = playerNavigator
+        self.musicPlayerService = musicPlayerService
         self.now = now
         // AllowanceEnforcerは@MainActor隔離のため、eventsの発行元は既にメインスレッド。receive(on:)によるhopは不要
         allowanceEnforcer.events
@@ -98,6 +101,11 @@ final class AllowanceSheetViewModel {
         } catch {
             errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
             return
+        }
+
+        // 境界停止で等速に戻された再生を、停止前の倍速で自動再開する (#87)
+        if let musicPlayerService {
+            Task { await musicPlayerService.resumeAfterRewardGrant() }
         }
 
         let shouldShowPrompt: Bool

--- a/Night-Core-Player/Services/MusicPlayerService.swift
+++ b/Night-Core-Player/Services/MusicPlayerService.swift
@@ -89,6 +89,8 @@ protocol MusicPlayerService: Sendable {
     func previous() async
     func seek(to time: TimeInterval) async
     func setSessionRate(_ rate: Double) async
+    /// 残高枯渇の曲境界停止からの復帰。停止前の倍速へ戻して再生を再開する (#87)
+    func resumeAfterRewardGrant() async
 
     func setQueue(songs: [Song], startAt index: Int, autoPlay: Bool) async
     func moveItem(from src: Int, to dst: Int) async

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -40,6 +40,8 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     private let now: () -> Date
 
     var currentPlaybackRate: Double = Constants.MusicPlayer.defaultPlaybackRate
+    /// 残高枯渇の曲境界停止時に保持する停止前の倍速。リワード付与後の自動復帰に使う (#87)
+    private var rateBeforeAllowanceStop: Double?
     private let minPlaybackRate: Double = Constants.MusicPlayer.minPlaybackRate
     private let maxPlaybackRate: Double = Constants.MusicPlayer.maxPlaybackRate
 
@@ -229,6 +231,8 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     }
 
     public func setSessionRate(_ rate: Double) async {
+        // 手動で倍速を変えたら、境界停止からの自動復帰情報は陳腐化する
+        rateBeforeAllowanceStop = nil
         currentPlaybackRate = Swift.min(Swift.max(rate, minPlaybackRate), maxPlaybackRate)
         player.playbackRate = currentPlaybackRate
         updateSnapshot()
@@ -724,6 +728,17 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
     }
 }
 
+extension MusicPlayerServiceImpl {
+    public func resumeAfterRewardGrant() async {
+        guard let savedRate = rateBeforeAllowanceStop else { return }
+        rateBeforeAllowanceStop = nil
+        // ユーザーが既に手動で再生を再開していたら、倍速だけ勝手に変えない
+        guard player.playbackState != .playing else { return }
+        currentPlaybackRate = savedRate
+        await play()
+    }
+}
+
 private extension MusicPlayerServiceImpl {
     /// 枯渇時は曲境界でのみ停止する。素の（等速）再生は制限しない
     func stopAtSongBoundaryIfNeeded(pausePlayer: Bool) -> Bool {
@@ -731,6 +746,7 @@ private extension MusicPlayerServiceImpl {
         if pausePlayer {
             player.pause()
         }
+        rateBeforeAllowanceStop = currentPlaybackRate
         currentPlaybackRate = Constants.MusicPlayer.normalPlaybackRate
         player.playbackRate = currentPlaybackRate
         enforcer.markStoppedAtSongEnd()

--- a/Night-Core-PlayerTests/Helpers/TestDataStore.swift
+++ b/Night-Core-PlayerTests/Helpers/TestDataStore.swift
@@ -1,0 +1,22 @@
+import SwiftData
+@testable import Night_Core_Player
+
+/// テスト用の in-memory ストア。実DB (AppDataStore.shared) を汚さないためのもの (#87)。
+/// プロセス内で共有される点は AppDataStore.shared と同じで、
+/// 「Repository を作り直しても状態が維持される」系のテスト前提を保つ
+@MainActor
+enum TestDataStore {
+    static let container: ModelContainer = {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        do {
+            return try ModelContainer(
+                for: PlayerStateEntity.self,
+                HistoryEntity.self,
+                AllowanceEntity.self,
+                configurations: config
+            )
+        } catch {
+            fatalError("テスト用 in-memory ModelContainer の初期化に失敗しました: \(error)")
+        }
+    }()
+}

--- a/Night-Core-PlayerTests/Mock/MusicPlayerServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/MusicPlayerServiceMock.swift
@@ -259,6 +259,11 @@ final class MusicPlayerServiceMock: MusicPlayerService {
         snapshotSubject.send(.empty.withRate(rate))
     }
 
+    public private(set) var resumeAfterRewardGrantCallCount = 0
+    public func resumeAfterRewardGrant() async {
+        resumeAfterRewardGrantCallCount += 1
+    }
+
     public func moveItem(from src: Int, to dst: Int) async {
         moveArgs.append((src, dst))
     }

--- a/Night-Core-PlayerTests/Services/AllowanceServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/AllowanceServiceTests.swift
@@ -14,7 +14,7 @@ struct AllowanceServiceTests {
     private static let daySeconds: TimeInterval = 86400
 
     private static func makeService() throws -> (service: AllowanceServiceImpl, repo: AllowanceRepository) {
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         let repo = AllowanceRepository(context: context)
         try repo.reset()
         let service = AllowanceServiceImpl(repo: repo)
@@ -202,7 +202,7 @@ struct AllowanceServiceTests {
         try service.markProPromptShown(now: now)
 
         // Service/Repository を作り直しても状態が維持される
-        let recreatedRepo = AllowanceRepository(context: AppDataStore.shared.container.mainContext)
+        let recreatedRepo = AllowanceRepository(context: TestDataStore.container.mainContext)
         let recreated = AllowanceServiceImpl(repo: recreatedRepo)
 
         let expectedRemaining =

--- a/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/MusicPlayerServiceTests.swift
@@ -34,7 +34,7 @@ private struct SUT {
     static func make(allowanceEnforcer: AllowanceEnforcer? = nil) -> SUT {
         let adapter   = PlayerControllableMock()
         let queueMock = QueueManagingMock()
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         let repo = PlayerStateRepository(context: context)
         let historyRepo = HistoryRepository(context: context)
         let rateManager = PlaybackRateManagerImpl(repo: repo)
@@ -222,7 +222,7 @@ struct MusicQueueManagerTests {
         queueMock.items = [A, B, C]
         queueMock.currentIndex = 0
 
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         let repo = PlayerStateRepository(context: context)
         let historyRepo = HistoryRepository(context: context)
         let service = MusicPlayerServiceImpl(

--- a/Night-Core-PlayerTests/Services/PlayHistoryManagerTests.swift
+++ b/Night-Core-PlayerTests/Services/PlayHistoryManagerTests.swift
@@ -14,7 +14,7 @@ struct PlayHistoryManagerTests {
         manager: PlayHistoryManagerImpl,
         historyRepo: HistoryRepository
     ) {
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         let historyRepo = HistoryRepository(context: context)
         let manager = PlayHistoryManagerImpl(historyRepo: historyRepo)
         return (manager, historyRepo)
@@ -22,7 +22,7 @@ struct PlayHistoryManagerTests {
 
     /// History をクリアする
     private static func cleanHistory() throws {
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         let histories = try context.fetch(FetchDescriptor<HistoryEntity>())
         histories.forEach(context.delete)
         try context.save()

--- a/Night-Core-PlayerTests/Services/PlaybackRateManagerTests.swift
+++ b/Night-Core-PlayerTests/Services/PlaybackRateManagerTests.swift
@@ -11,13 +11,13 @@ struct PlaybackRateManagerTests {
     // MARK: - Helpers
 
     private static func makeRepo() -> PlayerStateRepository {
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         return PlayerStateRepository(context: context)
     }
 
     /// PlayerState をクリアして初期状態にする
     private static func cleanPlayerState() throws {
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         let existing = try context.fetch(FetchDescriptor<PlayerStateEntity>())
         existing.forEach(context.delete)
         try context.save()

--- a/Night-Core-PlayerTests/Services/PlayerPersistenceServiceTests.swift
+++ b/Night-Core-PlayerTests/Services/PlayerPersistenceServiceTests.swift
@@ -15,7 +15,7 @@ struct PlayerPersistenceServiceTests {
         playerStateRepo: PlayerStateRepository,
         historyRepo: HistoryRepository
     ) {
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
         let playerStateRepo = PlayerStateRepository(context: context)
         let historyRepo = HistoryRepository(context: context)
         let service = PlayerPersistenceServiceImpl(
@@ -27,7 +27,7 @@ struct PlayerPersistenceServiceTests {
 
     /// PlayerState と History をクリアする
     private static func cleanAll() throws {
-        let context = AppDataStore.shared.container.mainContext
+        let context = TestDataStore.container.mainContext
 
         let playerStates = try context.fetch(FetchDescriptor<PlayerStateEntity>())
         playerStates.forEach(context.delete)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,8 +78,13 @@ platform :ios do
         "ja" => ENV["RELEASE_NOTE"] || "バグ修正とパフォーマンス改善",
         "en-US" => ENV["RELEASE_NOTE_EN"] || "Bug fixes and performance improvements"
       },
+      # AdMob 広告配信 + ATT 実装ありのため IDFA 使用を申告する (#77、codex レビュー指摘)
       submission_information: {
-        add_id_info_uses_idfa: false
+        add_id_info_uses_idfa: true,
+        add_id_info_serves_ads: true,
+        add_id_info_tracks_install: true,
+        add_id_info_tracks_action: false,
+        add_id_info_limits_tracking: true
       }
     )
   end


### PR DESCRIPTION
## 概要

issue #87 の2論点と、codex レビューで指摘された IDFA 回答の不整合 (#77) をまとめて修正。

## 変更内容

1. **リワード後の再生復帰 (#87-2)**: 曲境界停止時に停止前の倍速を保持し、リワード付与成功後に `resumeAfterRewardGrant()` で元の速度のまま再生を自動再開。ユーザーが既に手動で再生・倍速変更していたら何もしない
2. **テスト汚染 (#87-1)**: 残高・履歴系テストの `AppDataStore.shared` を in-memory の `TestDataStore` に差し替え。テスト実行後のシミュレータ実DBに残高データが残らない
3. **IDFA (#77)**: `add_id_info_uses_idfa: false` → 実態 (AdMob 広告配信 + ATT) に合わせて `true` + 詳細回答

## 検証

- 全ユニットテスト通過 (in-memory 化後も含む)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoTgSCyVLzNfESbTQZMoeP