### PR TITLE
fix: 実機検証で判明したプレイリスト・課金・レイアウトの不具合を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ fastlane/README.md
 
 # Build artifacts
 build/
+.derivedData/
 *.ipa
 *.dSYM.zip
 

--- a/Night-Core-Player/Core/UIConstants.swift
+++ b/Night-Core-Player/Core/UIConstants.swift
@@ -35,6 +35,12 @@ extension Constants {
             public static let speedControlSliderWidth: CGFloat = 340.0
             public static let playlistIconWidth: CGFloat = 24.0
             public static let miniMusicPlayerHeight: CGFloat = 55.0
+            /// ミニプレイヤーをタブバーの上へ持ち上げる量
+            public static let miniMusicPlayerBottomOffset: CGFloat = 55.0
+            /// ミニプレイヤーが画面下端から覆う総量。各スクロール画面の下端余白に使う
+            public static var miniMusicPlayerContentInset: CGFloat {
+                miniMusicPlayerHeight + miniMusicPlayerBottomOffset
+            }
         }
 
         public enum Padding {

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
@@ -83,6 +83,8 @@ final class AllowanceSheetViewModel {
                 switch try await proStoreService.purchase() {
                 case .purchased:
                     close()
+                case .unavailable:
+                    errorMessage = String(localized: "Pro is not available right now. Please try again later.")
                 case .cancelled, .pending:
                     break
                 }

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -33,20 +33,20 @@ struct MainTabView: View {
                     .tag(PlayerNavigator.Tab.player)
                     .safeAreaPadding(.bottom, miniPlayerHeight)
 
+                // 以下3タブの下端余白は各画面のList側(contentMargins)が持つ。
+                // NavigationStack越しのsafeAreaPaddingは内部Listのスクロール余白に届かず、
+                // ミニプレイヤーが最下行に被って操作できなくなるため
                 SearchView()
                     .tabItem { Label("Search", systemImage: "magnifyingglass") }
                     .tag(PlayerNavigator.Tab.search)
-                    .safeAreaPadding(.bottom, miniPlayerHeight)
 
                 PlaylistView()
                     .tabItem { Label("Playlist", systemImage: "list.bullet") }
                     .tag(PlayerNavigator.Tab.playlist)
-                    .safeAreaPadding(.bottom, miniPlayerHeight)
 
                 SettingsView()
                     .tabItem { Label("Settings", systemImage: "gearshape") }
                     .tag(PlayerNavigator.Tab.settings)
-                    .safeAreaPadding(.bottom, miniPlayerHeight)
             }
             .onScrollDetected { scrolling in
                 nav.isScrolling = scrolling
@@ -88,7 +88,7 @@ struct MainTabView: View {
                             nav.selectedTab = .player
                         }
                     }
-                    .padding(.bottom, 55)
+                    .padding(.bottom, Constants.UI.FrameSize.miniMusicPlayerBottomOffset)
                     .opacity(nav.isScrolling ? 0.3 : 1.0)
                     .animation(.easeInOut(duration: 0.2), value: nav.isScrolling)
             }

--- a/Night-Core-Player/Features/Playlist/PlaylistView.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistView.swift
@@ -80,6 +80,7 @@ struct PlaylistView: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        .contentMargins(.bottom, Constants.UI.FrameSize.miniMusicPlayerContentInset, for: .scrollContent)
         .background(Color(.systemBackground))
     }
 }

--- a/Night-Core-Player/Features/Playlist/PlaylistViewModel.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistViewModel.swift
@@ -7,12 +7,10 @@ import Observation
 @MainActor
 final class PlaylistViewModel {
 
-    var playlists: [Playlist] = []
     var rows: [PlaylistRowModel] = []
     var isLoading = false
     var errorMessage: String?
 
-    private var artworkCache: [MusicItemID: UIImage] = [:]
     private let musicKitService: MusicKitService
 
     init(musicKitService: MusicKitService) {
@@ -26,7 +24,7 @@ final class PlaylistViewModel {
 
         do {
             let playlists = try await musicKitService.fetchLibraryPlaylists(limit: limit)
-            self.rows = playlists.map { pl in
+            rows = playlists.map { pl in
                 PlaylistRowModel(
                     id: pl.id,
                     title: pl.name,
@@ -35,39 +33,9 @@ final class PlaylistViewModel {
                 )
             }
             errorMessage = nil
-
-            await withTaskGroup(of: Void.self) { group in
-                for pl in playlists {
-                    group.addTask { [weak self] in
-                        await self?.fetchArtwork(for: pl)
-                    }
-                }
-            }
         } catch {
             errorMessage = error.localizedDescription
-            playlists = []
-        }
-    }
-
-    // MARK: - Artwork 取得
-    private func fetchArtwork(for playlist: Playlist) async {
-        guard let url = playlist.artwork?.url(width: 100, height: 100) else { return }
-        do {
-            let (data, _) = try await URLSession.shared.data(from: url)
-            guard let uiImage = UIImage(data: data) else { return }
-
-            artworkCache[playlist.id] = uiImage
-
-            if let idx = rows.firstIndex(where: { $0.id == playlist.id }) {
-                rows[idx] = PlaylistRowModel(
-                    id: rows[idx].id,
-                    title: rows[idx].title,
-                    artwork: rows[idx].artwork,
-                    playlist: rows[idx].playlist
-                )
-            }
-
-        } catch {
+            rows = []
         }
     }
 }

--- a/Night-Core-Player/Features/Search/SearchView.swift
+++ b/Night-Core-Player/Features/Search/SearchView.swift
@@ -112,6 +112,7 @@ struct SearchView: View {
                         }
                     }
                     .listStyle(PlainListStyle())
+                    .contentMargins(.bottom, Constants.UI.FrameSize.miniMusicPlayerContentInset, for: .scrollContent)
                 } else if vm.query.isEmpty && !vm.searchHistory.isEmpty {
                     searchHistoryView
                 }
@@ -187,6 +188,7 @@ struct SearchView: View {
                 }
             }
             .listStyle(.plain)
+            .contentMargins(.bottom, Constants.UI.FrameSize.miniMusicPlayerContentInset, for: .scrollContent)
         }
     }
 

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -78,6 +78,7 @@ struct SettingsView: View {
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
+            .contentMargins(.bottom, Constants.UI.FrameSize.miniMusicPlayerContentInset, for: .scrollContent)
             .background(Color(.systemBackground))
             .navigationTitle("Settings")
             .navigationDestination(for: SoundItem.self) { item in
@@ -93,23 +94,31 @@ struct SettingsView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .alert("Error", isPresented: Binding<Bool>(
-            get: { settingsVM.errorMessage != nil },
-            set: { if !$0 { settingsVM.errorMessage = nil } }
+        // 同一ViewへのalertはSwiftUIが片方しか表示しないため、エラーと通知を1つに統合する
+        .alert(alertTitle, isPresented: Binding<Bool>(
+            get: { alertMessage != nil },
+            set: { if !$0 { dismissAlert() } }
         )) {
-            Button("OK") { settingsVM.errorMessage = nil }
+            Button("OK") { dismissAlert() }
         } message: {
-            Text(settingsVM.errorMessage ?? "")
-        }
-        .alert("Pro", isPresented: Binding<Bool>(
-            get: { settingsVM.infoMessage != nil },
-            set: { if !$0 { settingsVM.infoMessage = nil } }
-        )) {
-            Button("OK") { settingsVM.infoMessage = nil }
-        } message: {
-            Text(settingsVM.infoMessage ?? "")
+            Text(alertMessage ?? "")
         }
         .enableInjection()
+    }
+
+    // MARK: - Alert
+
+    private var alertMessage: String? {
+        settingsVM.errorMessage ?? settingsVM.infoMessage
+    }
+
+    private var alertTitle: LocalizedStringKey {
+        settingsVM.errorMessage != nil ? "Error" : "Pro"
+    }
+
+    private func dismissAlert() {
+        settingsVM.errorMessage = nil
+        settingsVM.infoMessage = nil
     }
 
     // MARK: - Allowance

--- a/Night-Core-Player/Features/Settings/SettingsViewModel.swift
+++ b/Night-Core-Player/Features/Settings/SettingsViewModel.swift
@@ -89,6 +89,8 @@ final class SettingsViewModel {
                 switch try await proStore.purchase() {
                 case .pending:
                     infoMessage = String(localized: "Purchase pending approval")
+                case .unavailable:
+                    errorMessage = String(localized: "Pro is not available right now. Please try again later.")
                 case .purchased, .cancelled:
                     break
                 }

--- a/Night-Core-Player/Localizable.xcstrings
+++ b/Night-Core-Player/Localizable.xcstrings
@@ -481,6 +481,16 @@
         }
       }
     },
+    "Pro is not available right now. Please try again later.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proを取得できませんでした。しばらくしてからもう一度お試しください。"
+          }
+        }
+      }
+    },
     "OK": {
       "localizations": {
         "ja": {

--- a/Night-Core-Player/Services/ProStoreService.swift
+++ b/Night-Core-Player/Services/ProStoreService.swift
@@ -10,6 +10,8 @@ enum ProPurchaseOutcome {
     case purchased
     case cancelled
     case pending
+    /// 商品をStoreKitから取得できず購入を開始できなかった。ユーザー操作によるcancelledと区別する
+    case unavailable
 }
 
 // MARK: - Protocol
@@ -68,7 +70,7 @@ final class ProStoreServiceImpl: ProStoreService {
             product = loaded
         } else {
             logger.error("Pro product not found: \(Self.productID)")
-            return .cancelled
+            return .unavailable
         }
         let result = try await product.purchase()
         switch result {


### PR DESCRIPTION
実機 (iPhone 13 / iOS 26.6) で動作確認したところ見つかった不具合をまとめて修正した。

## 修正内容

### Playlist が読み込み中のまま止まる
`PlaylistViewModel` が、描画に使われないアートワークを URLSession で先読みし、その全件完了まで `isLoading` を解除していなかった。`PlaylistView` は `ArtworkImage` が MusicKit の `Artwork` から直接描画しており、先読みした `UIImage` はどこにも渡っていなかったため、処理ごと削除した。あわせてエラー時に `rows` が残る問題も直した。

### Pro 購入を押しても無反応
商品を取得できないケースをユーザーのキャンセルと同一視しており、呼び出し側が握りつぶしていた。`ProPurchaseOutcome` に `unavailable` を追加し、設定画面と残高シートの双方でエラーを表示する。

### ミニプレイヤーが最下行に被って操作できない
`NavigationStack` の外側からの `safeAreaPadding` は内部 `List` のスクロール余白に届かないため、下端余白の責務を各画面の `contentMargins` に移した。確保量はミニプレイヤーの実占有量 (本体の高さ + タブバー上への持ち上げ量) に合わせ、`UIConstants` で両者が同じ定義から導かれるようにした。Search / Playlist / Settings の 3 画面が対象。

### 設定画面のエラーが表示されない
同一 View に `alert` を 2 つ重ねており、SwiftUI が片方を無視していた。1 つに統合した。

## 確認

- 実機 (iPhone 13 / iOS 26.6) で 4 点とも解消を確認
- `xcodebuild test` → **TEST SUCCEEDED**
- `swiftlint` → 変更ファイル 9 件で違反 0

## 補足

Pro の商品が取得できない事象そのものは解消していない。App Store Connect 側の商品登録または契約の問題であり、本 PR は「失敗をユーザーに伝える」ようにしたもの。