### PR TITLE
feat: 残高・広告の実機検証を可能にするデバッグ入口と枠超過ダイアログの刷新

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ PROJECT := Night-Core-Player.xcodeproj
 SCHEME := Night-Core-Player
 
 # ローカル環境に合わせて上書き可: make test DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro'
-DESTINATION ?= platform=iOS Simulator,name=iPhone SE (3rd generation)
+# OS=latest は必須: 同名デバイスが複数ランタイムに存在するため、省略すると宛先が一意に定まらず Error 70 になる
+# 端末名は最新ランタイムに存在するものを指定する（iPhone SE は iOS 18 系までのため latest では見つからない）
+DESTINATION ?= platform=iOS Simulator,name=iPhone 17,OS=latest
 
 .PHONY: check build lint swiftformat-lint test format
 

--- a/Night-Core-Player/Core/UIConstants.swift
+++ b/Night-Core-Player/Core/UIConstants.swift
@@ -34,6 +34,8 @@ extension Constants {
             public static let buttonMinHeight: CGFloat = 42.0
             public static let speedControlSliderWidth: CGFloat = 340.0
             public static let playlistIconWidth: CGFloat = 24.0
+            /// 中央ダイアログの最大幅。ボタンが端まで伸びて間延びしないよう抑える
+            public static let dialogMaxWidth: CGFloat = 320.0
             public static let miniMusicPlayerHeight: CGFloat = 55.0
             /// ミニプレイヤーをタブバーの上へ持ち上げる量
             public static let miniMusicPlayerBottomOffset: CGFloat = 55.0

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetView.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetView.swift
@@ -4,23 +4,8 @@ struct AllowanceSheetView: View {
     let viewModel: AllowanceSheetViewModel
 
     var body: some View {
-        VStack(spacing: 24) {
-            VStack(spacing: 8) {
-                Text(viewModel.showProPromptPitch ? "+30 Minutes Added" : "Today's Free Playback Time Is Used Up")
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                Text("Normal-speed playback is still free")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
-            .multilineTextAlignment(.center)
-
-            if viewModel.showProPromptPitch {
-                Text("You've watched 5 ads. Go Pro and you'll never need to again.")
-                    .font(.footnote)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-            }
+        VStack(spacing: 20) {
+            header
 
             if let errorMessage = viewModel.errorMessage {
                 Text(errorMessage)
@@ -29,44 +14,127 @@ struct AllowanceSheetView: View {
                     .multilineTextAlignment(.center)
             }
 
-            VStack(spacing: 12) {
-                Button {
-                    viewModel.watchAdForReward()
-                } label: {
-                    if viewModel.isWatchingAd {
-                        ProgressView()
-                            .frame(maxWidth: .infinity)
-                    } else {
-                        Text("Watch a Video for +30 Minutes")
-                            .frame(maxWidth: .infinity)
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(viewModel.showProPromptPitch || viewModel.isWatchingAd)
-                .accessibilityIdentifier("allowance_reward_button")
+            options
 
-                Button {
-                    viewModel.purchasePro()
-                } label: {
-                    if viewModel.isPurchasing {
-                        ProgressView()
-                            .frame(maxWidth: .infinity)
-                    } else {
-                        Text("Go Unlimited with Pro (One-Time Purchase)")
-                            .frame(maxWidth: .infinity)
-                    }
-                }
-                .buttonStyle(.bordered)
-                .disabled(viewModel.isPurchasing)
-                .accessibilityIdentifier("allowance_pro_button")
-
-                Button("Close") {
-                    viewModel.close()
-                }
-                .accessibilityIdentifier("allowance_close_button")
+            Button("Close") {
+                viewModel.close()
             }
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+            .accessibilityIdentifier("allowance_close_button")
         }
-        .padding()
+        .padding(24)
         .accessibilityIdentifier("allowance_sheet")
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 6) {
+            Text(viewModel.showProPromptPitch ? "+30 Minutes Added" : "Today's Free Playback Time Is Used Up")
+                .font(.title3)
+                .fontWeight(.semibold)
+            Text(viewModel.showProPromptPitch
+                ? "You've watched 5 ads. Go Pro and you'll never need to again."
+                : "Normal-speed playback is still free")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .multilineTextAlignment(.center)
+    }
+
+    // MARK: - Options
+
+    private var options: some View {
+        VStack(spacing: 0) {
+            optionRow(
+                icon: "play.rectangle.fill",
+                title: "Watch a Video",
+                badge: "+30 min",
+                detail: "Adds playback time for today",
+                isBusy: viewModel.isWatchingAd,
+                isEnabled: !viewModel.showProPromptPitch && !viewModel.isWatchingAd,
+                action: { viewModel.watchAdForReward() }
+            )
+            .accessibilityIdentifier("allowance_reward_button")
+
+            Divider()
+                .padding(.leading, 56)
+
+            optionRow(
+                icon: "infinity",
+                title: "Go Pro",
+                badge: "One-time",
+                detail: "Unlimited playback, no ads",
+                isBusy: viewModel.isPurchasing,
+                isEnabled: !viewModel.isPurchasing,
+                action: { viewModel.purchasePro() }
+            )
+            .accessibilityIdentifier("allowance_pro_button")
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    private func optionRow(
+        icon: String,
+        title: LocalizedStringKey,
+        badge: LocalizedStringKey,
+        detail: LocalizedStringKey,
+        isBusy: Bool,
+        isEnabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.title3)
+                    .foregroundColor(.indigo)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Text(title)
+                            .font(.body)
+                            .foregroundColor(.primary)
+                        badgeLabel(badge)
+                    }
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: 8)
+
+                if isBusy {
+                    ProgressView()
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1.0 : 0.4)
+    }
+
+    private func badgeLabel(_ text: LocalizedStringKey) -> some View {
+        Text(text)
+            .font(.caption2)
+            .fontWeight(.medium)
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(Color(.tertiarySystemFill))
+            )
     }
 }

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
@@ -134,6 +134,13 @@ final class AllowanceSheetViewModel {
         }
     }
 
+    #if DEBUG
+        /// 検証用: 曲末の停止を待たずに枠超過シートを開く。リワード広告の実機確認に使う
+        func debugPresent() {
+            present()
+        }
+    #endif
+
     private func present() {
         errorMessage = nil
         showProPromptPitch = false

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -15,6 +15,25 @@ struct MainTabView: View {
         nav.selectedTab != .player && !keyboard.isVisible
     }
 
+    /// 枠超過の告知はタブ全体を覆うシートではなく中央のダイアログで出す
+    private var allowanceDialog: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .onTapGesture { allowanceSheetVM.close() }
+
+            AllowanceSheetView(viewModel: allowanceSheetVM)
+                .frame(maxWidth: Constants.UI.FrameSize.dialogMaxWidth)
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color(.systemBackground))
+                )
+                .shadow(radius: 20)
+                .padding(24)
+        }
+        .transition(.opacity)
+    }
+
     var body: some View {
         @Bindable var nav = nav
         let tabBinding = Binding<PlayerNavigator.Tab>(
@@ -93,12 +112,12 @@ struct MainTabView: View {
                     .animation(.easeInOut(duration: 0.2), value: nav.isScrolling)
             }
         }
-        .sheet(isPresented: Binding(
-            get: { allowanceSheetVM.isPresented },
-            set: { isPresented in if !isPresented { allowanceSheetVM.close() } }
-        )) {
-            AllowanceSheetView(viewModel: allowanceSheetVM)
+        .overlay {
+            if allowanceSheetVM.isPresented {
+                allowanceDialog
+            }
         }
+        .animation(.easeInOut(duration: 0.2), value: allowanceSheetVM.isPresented)
         .enableInjection()
     }
 }

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @ObserveInjection var inject
     @Environment(SettingsViewModel.self) private var settingsVM
     @Environment(\.requestReview) private var requestReview
+    @Environment(AllowanceSheetViewModel.self) private var allowanceSheetVM
 
     private enum SoundItem: String, CaseIterable, Hashable {
         case playbackSpeed
@@ -60,6 +61,10 @@ struct SettingsView: View {
 
                 proSection
 
+                #if DEBUG
+                    debugSection
+                #endif
+
                 Section {
                     ForEach(OtherItem.allCases, id: \.self) { item in
                         VStack(spacing: 0) {
@@ -90,7 +95,12 @@ struct SettingsView: View {
                 }
             }
             .task {
+                settingsVM.refreshAllowance()
                 await settingsVM.loadProState()
+            }
+            // リワード付与は枠超過シート側で起きるため、閉じた時点で残高表示を追随させる
+            .onChange(of: allowanceSheetVM.isPresented) { _, isPresented in
+                if !isPresented { settingsVM.refreshAllowance() }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -105,6 +115,43 @@ struct SettingsView: View {
         }
         .enableInjection()
     }
+
+    #if DEBUG
+        // MARK: - Debug
+
+        /// 残高の状態を手で作るための検証用セクション。トライアル中は枠超過シートに到達できず
+        /// リワード広告を実機確認できないため置いている
+        private var debugSection: some View {
+            Section {
+                debugRow("残高を使い切る（トライアル終了）") { settingsVM.debugExhaustAllowance() }
+                debugRow("残高の記録を消す") { settingsVM.debugResetAllowance() }
+                // 枠超過シートは曲が終わったときにだけ出るため、広告確認のために直接開く口を用意する
+                debugRow("枠超過シートを開く") { allowanceSheetVM.debugPresent() }
+            } header: {
+                Text("デバッグ（Debug ビルドのみ）")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                    .padding(.top, 8)
+            }
+        }
+
+        private func debugRow(_ title: LocalizedStringKey, action: @escaping () -> Void) -> some View {
+            VStack(spacing: 0) {
+                Button(action: action) {
+                    HStack {
+                        Text(title)
+                            .font(.body)
+                            .foregroundColor(.primary)
+                        Spacer()
+                    }
+                    .padding(.vertical, 12)
+                }
+                Divider()
+                    .padding(.leading, 16)
+            }
+            .listRowSeparator(.hidden)
+        }
+    #endif
 
     // MARK: - Alert
 

--- a/Night-Core-Player/Features/Settings/SettingsViewModel.swift
+++ b/Night-Core-Player/Features/Settings/SettingsViewModel.swift
@@ -12,8 +12,18 @@ final class SettingsViewModel {
     var isProEntitled: Bool { proStore?.isProEntitled ?? false }
     private(set) var proPriceText: String?
 
+    /// AllowanceService は @Observable ではなく、残高の変化を SwiftUI が追跡できない。
+    /// この値の更新が remainingTimeText の再評価契機になる
+    private var allowanceRevision = 0
+
+    /// 残高が外部（リワード付与など）で変わった後に表示を追随させる
+    func refreshAllowance() {
+        allowanceRevision += 1
+    }
+
     /// 今日の残り再生時間の表示テキスト。Pro > トライアル > 無料残高/枯渇の優先順位で判定する
     var remainingTimeText: String {
+        _ = allowanceRevision
         guard let allowanceService else { return "" }
         if isProEntitled {
             return String(localized: "Unlimited")
@@ -100,6 +110,36 @@ final class SettingsViewModel {
             await loadProState()
         }
     }
+
+    #if DEBUG
+        /// 検証用: 残高を使い切った状態にする。再生を試みると枠超過シート（リワード広告の入口）に到達する
+        func debugExhaustAllowance() {
+            applyDebugAllowanceChange(String(localized: "Allowance exhausted")) {
+                try $0.debugExhaust(now: Date())
+            }
+        }
+
+        /// 検証用: 残高の記録を消し、トライアルからやり直す
+        func debugResetAllowance() {
+            applyDebugAllowanceChange(String(localized: "Allowance reset")) {
+                try $0.debugReset()
+            }
+        }
+
+        private func applyDebugAllowanceChange(
+            _ message: String,
+            _ change: (AllowanceService) throws -> Void
+        ) {
+            guard let allowanceService else { return }
+            do {
+                try change(allowanceService)
+                refreshAllowance()
+                infoMessage = message
+            } catch {
+                errorMessage = (error as? AppError)?.errorDescription ?? error.localizedDescription
+            }
+        }
+    #endif
 
     func restorePro() {
         Task {

--- a/Night-Core-Player/Localizable.xcstrings
+++ b/Night-Core-Player/Localizable.xcstrings
@@ -481,6 +481,26 @@
         }
       }
     },
+    "Allowance exhausted": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残高を使い切った状態にしました"
+          }
+        }
+      }
+    },
+    "Allowance reset": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残高の記録を消去しました"
+          }
+        }
+      }
+    },
     "Pro is not available right now. Please try again later.": {
       "localizations": {
         "ja": {
@@ -521,22 +541,62 @@
         }
       }
     },
-    "Watch a Video for +30 Minutes": {
+    "Watch a Video": {
       "localizations": {
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "動画を視聴し再生時間を30分追加"
+            "value": "動画を見る"
           }
         }
       }
     },
-    "Go Unlimited with Pro (One-Time Purchase)": {
+    "+30 min": {
       "localizations": {
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proプランで無制限再生"
+            "value": "+30分"
+          }
+        }
+      }
+    },
+    "Adds playback time for today": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日の再生時間を追加します"
+          }
+        }
+      }
+    },
+    "Go Pro": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proにする"
+          }
+        }
+      }
+    },
+    "One-time": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "買い切り"
+          }
+        }
+      }
+    },
+    "Unlimited playback, no ads": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時間制限なし・広告なしで使えます"
           }
         }
       }

--- a/Night-Core-Player/Services/AllowanceService.swift
+++ b/Night-Core-Player/Services/AllowanceService.swift
@@ -9,6 +9,13 @@ protocol AllowanceService: Sendable {
     func grantReward(now: Date) throws -> TimeInterval
     func shouldShowProPrompt(now: Date) throws -> Bool
     func markProPromptShown(now: Date) throws
+
+    #if DEBUG
+        /// 検証用: トライアルを終了させ残高を使い切った状態にする。リワード広告と枯渇シートの実機確認に使う
+        func debugExhaust(now: Date) throws
+        /// 検証用: 残高の記録を消し、初回起動前の状態に戻す
+        func debugReset() throws
+    #endif
 }
 
 // MARK: - Impl
@@ -62,6 +69,25 @@ final class AllowanceServiceImpl: AllowanceService {
         snapshot.proPromptShown = true
         try repo.save(snapshot)
     }
+
+    #if DEBUG
+        func debugExhaust(now: Date) throws {
+            var snapshot = try normalizedSnapshot(now: now)
+            // トライアル判定を抜けるため初回起動をトライアル期間より前に倒す
+            snapshot.firstLaunchAt = now.addingTimeInterval(
+                -TimeInterval(Constants.Allowance.trialDays + 1) * Self.daySeconds
+            )
+            snapshot.remainingSeconds = 0
+            // normalizedSnapshot の日次リセットで残高が戻らないよう次回リセットを先送りする
+            snapshot.nextResetAt = now.addingTimeInterval(Self.daySeconds)
+            snapshot.lastSeenAt = now
+            try repo.save(snapshot)
+        }
+
+        func debugReset() throws {
+            try repo.reset()
+        }
+    #endif
 
     // MARK: - Private
 

--- a/Night-Core-PlayerTests/Mock/AllowanceServiceMock.swift
+++ b/Night-Core-PlayerTests/Mock/AllowanceServiceMock.swift
@@ -42,4 +42,13 @@ final class AllowanceServiceMock: AllowanceService {
         }
         proPromptShown = true
     }
+
+    func debugExhaust(now: Date) throws {
+        entitlementResult = .exhausted
+    }
+
+    func debugReset() throws {
+        entitlementResult = .free(remaining: Constants.Allowance.dailyFreeSeconds)
+        proPromptShown = false
+    }
 }


### PR DESCRIPTION
実機 (iPhone 13 / iOS 26.6) でリワード広告を検証できる状態にし、そこで見つかった不具合と UI を修正した。

## 背景

トライアル中は残高が枯渇せず、リワード広告の入口である枠超過シートに到達できないため、#62 で AdMob を導入して以降、広告まわりを実機で一度も確認できていなかった。

## 変更内容

### `make test` が起動しない問題を修正
同名シミュレータが複数ランタイムに存在し宛先が一意に定まらず、`Error 70` でテストが実行されていなかった。`OS=latest` を付けたうえで、最新ランタイムに実在する端末名を指定する。

### 残高操作のデバッグ入口を追加 (DEBUG ビルド限定)
設定画面に、残高の枯渇・記録の消去・枠超過ダイアログの直接表示を行うセクションを追加した。`#if DEBUG` で囲っているため Release ビルドには含まれない。

### 残り再生時間が更新されない不具合を修正
`AllowanceService` は `@Observable` ではなく SwiftUI が残高の変化を追跡できないため、リワードで付与しても設定画面の表示が古いままだった。画面表示時と枠超過ダイアログを閉じた時点で再評価する。

### 枠超過の告知をダイアログに変更
画面下から出るシートは告知の重さに対して過剰で、全幅ボタンが縦に並ぶ見た目も間延びしていた。中央に浮かぶ幅制限つきのダイアログに変え、リワードと Pro をアイコン・バッジ・説明を持つ行として並べる。背景タップで閉じられる。

## 実機で確認したこと

- AdMob のリワード広告が表示される (テストユニット ID)
- 視聴後に +30 分が付与され、表示に反映される
- ダイアログが中央に表示され、背景タップで閉じる
- `make test` が完走する

## 補足

Pro の商品は取得できないままで、App Store Connect 側の未対応事項として残っている。本 PR の範囲外。