### PR TITLE
fix: Pro の製品IDをApp Store Connectで登録可能な形式に変更

### DIFF
--- a/Night-Core-Player/NightCorePlayer.storekit
+++ b/Night-Core-Player/NightCorePlayer.storekit
@@ -20,7 +20,7 @@
           "locale" : "ja_JP"
         }
       ],
-      "productID" : "MizuRyu.Night-Core-Player.pro",
+      "productID" : "MizuRyu.NightCorePlayer.pro",
       "referenceName" : "Pro",
       "type" : "NonConsumable"
     }

--- a/Night-Core-Player/Services/ProStoreService.swift
+++ b/Night-Core-Player/Services/ProStoreService.swift
@@ -31,7 +31,7 @@ protocol ProStoreService: Sendable {
 final class ProStoreServiceImpl: ProStoreService {
     private let logger = Logger(subsystem: Constants.Logging.subsystem, category: "ProStore")
 
-    static let productID = "MizuRyu.Night-Core-Player.pro"
+    static let productID = "MizuRyu.NightCorePlayer.pro"
 
     private(set) var isProEntitled = false
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Apple Music の等速再生は無料・無制限。Nightcore 変換（`playbackR
 - トライアル終了後: 1日 3600 秒（日次リセット、繰越なし）
 - リワード広告視聴で +1800 秒
 - 累計 5 回のリワード後に Pro 訴求を 1 回表示
-- Pro（`MizuRyu.Night-Core-Player.pro`、StoreKit 2 非消耗型）購入で無制限化
+- Pro（`MizuRyu.NightCorePlayer.pro`、StoreKit 2 非消耗型）購入で無制限化
 
 残高が尽きても即停止はせず、曲の切れ目まで再生してから停止する（BGM 用途でのブツ切りを避けるため）。詳細は [docs/adr/003-allowance-design.md](docs/adr/003-allowance-design.md) を参照。
 

--- a/docs/specs/ARCHITECTURE.md
+++ b/docs/specs/ARCHITECTURE.md
@@ -176,7 +176,7 @@ Night-Core-Player/
 |---------|------|--------|
 | `AllowanceService` | `AllowanceSnapshot`（残高・トライアル終了日・リワード回数等）の読み書きと、日次リセット・トライアル判定などの状態遷移 | する（`AllowanceRepository` 経由で SwiftData） |
 | `AllowanceEnforcer` | `MusicPlayerServiceImpl` の再生 tick から呼ばれ、倍速再生時のみ経過時間を `AllowanceService.consume` に渡す。残高が尽きたら即停止せず、現在の曲が終わるまで再生を続けたうえで停止する（曲境界停止） | しない（メモリ上のフラグのみ） |
-| `ProStoreService` | StoreKit 2 で Pro（非消耗型 `MizuRyu.Night-Core-Player.pro`）を購入・復元し、`isProEntitled` を公開する。Pro ユーザーは `AllowanceEnforcer` の消費・停止の対象外 | StoreKit のトランザクション履歴に委譲 |
+| `ProStoreService` | StoreKit 2 で Pro（非消耗型 `MizuRyu.NightCorePlayer.pro`）を購入・復元し、`isProEntitled` を公開する。Pro ユーザーは `AllowanceEnforcer` の消費・停止の対象外 | StoreKit のトランザクション履歴に委譲 |
 
 **設計上の制約:** 残高ゲートは Nightcore 変換（`playbackRate != 1.0`）にのみ掛ける。Apple Music の素の等速再生は制限しない（MusicKit 利用規約上、等速再生を課金対象にできないため）。時計を過去に戻す操作への対策として `guardedNow = max(now, lastSeenAt)` を使い、残高の巻き戻りを防いでいる。背景は [ADR 003](../adr/003-allowance-design.md) を参照。
 


### PR DESCRIPTION
App Store Connect にアプリ内課金 Pro を登録するにあたり、製品IDを変更した。

## 背景

Pro の購入で商品が取得できず価格も表示されなかった原因は、実装ではなく **App Store Connect にアプリ内課金が1件も登録されていなかった**こと。契約側 (有料アプリ契約・銀行口座・納税フォーム) はいずれも有効だった。

登録を進めたところ、製品ID `MizuRyu.Night-Core-Player.pro` は受け付けられなかった。App Store Connect の製品IDは英数字・ピリオド・下線のみを許可し、ハイフンを含められないため。バンドルID (`MizuRyu.Night-Core-Player`) とは制約が異なる。

## 変更内容

製品IDを `MizuRyu.NightCorePlayer.pro` に変更し、以下を揃えた。

- `ProStoreService.productID`
- `NightCorePlayer.storekit` (StoreKit Configuration)
- `README.md` / `docs/specs/ARCHITECTURE.md`

## App Store Connect 側の設定 (このPRの範囲外・作業済み)

| 項目 | 値 |
|---|---|
| 製品ID | `MizuRyu.NightCorePlayer.pro` |
| タイプ | 非消耗型 |
| 価格 | ¥500 (日本基準、175地域へ自動換算) |
| 配信可否 | 選択されたすべての国または地域 |
| ローカリゼーション | 日本語 / 英語 (アメリカ) |
| ステータス | 提出準備中 |

## 確認

- `make test` → **TEST SUCCEEDED**
- 実機ビルド (iPhone 13 / iOS 26.6) 成功
- `swiftlint` 違反 0

## 残件

実機での購入フロー確認は未了。最初のアプリ内課金は新しいアプリバージョンとともに審査提出する必要があるため、#76 の TestFlight 検証に合わせて商品を「審査用に追加」して確認する。それより早く確認したい場合は、スキームに設定済みの StoreKit Configuration を使って Xcode から Run すればローカルで完結する。