### PR TITLE
fix: 敵対的レビュー対応 — 枯渇後の猶予の抜け穴、ダイアログの処理中操作、余白漏れ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ track2.mp4
 buildServer.json
 xcuserdata/
 __azurite_db_queue__.json
+.DS_Store
 
 # Secrets
 .secrets/
@@ -18,7 +19,7 @@ fastlane/README.md
 
 # Build artifacts
 build/
-.derivedData/
+.derivedData*/
 *.ipa
 *.dSYM.zip
 

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetView.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetView.swift
@@ -17,10 +17,11 @@ struct AllowanceSheetView: View {
             options
 
             Button("Close") {
-                viewModel.close()
+                viewModel.dismissByUser()
             }
             .font(.subheadline)
             .foregroundColor(.secondary)
+            .disabled(viewModel.isBusy)
             .accessibilityIdentifier("allowance_close_button")
         }
         .padding(24)

--- a/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
+++ b/Night-Core-Player/Features/Allowance/AllowanceSheetViewModel.swift
@@ -45,12 +45,22 @@ final class AllowanceSheetViewModel {
             .store(in: &cancellables)
     }
 
+    /// 広告視聴中・購入中
+    var isBusy: Bool { isWatchingAd || isPurchasing }
+
+    /// 閉じるボタン・背景タップからの明示的な操作。処理中は結果もエラーも見えなくなるため塞ぐ
+    /// （購入成功後の自動クローズは処理中に呼ばれるため close() を使う）
+    func dismissByUser() {
+        guard !isBusy else { return }
+        close()
+    }
+
     func close() {
         isPresented = false
     }
 
     func watchAdForReward() {
-        guard !isWatchingAd else { return }
+        guard !isBusy else { return }
         errorMessage = nil
 
         guard let rewardedAdService else {
@@ -76,7 +86,7 @@ final class AllowanceSheetViewModel {
     func purchasePro() {
         errorMessage = nil
         Task {
-            guard !isPurchasing else { return }
+            guard !isBusy else { return }
             isPurchasing = true
             defer { isPurchasing = false }
             do {

--- a/Night-Core-Player/Features/Common/MainTabView.swift
+++ b/Night-Core-Player/Features/Common/MainTabView.swift
@@ -20,18 +20,24 @@ struct MainTabView: View {
         ZStack {
             Color.black.opacity(0.4)
                 .ignoresSafeArea()
-                .onTapGesture { allowanceSheetVM.close() }
+                .onTapGesture { allowanceSheetVM.dismissByUser() }
 
-            AllowanceSheetView(viewModel: allowanceSheetVM)
-                .frame(maxWidth: Constants.UI.FrameSize.dialogMaxWidth)
-                .background(
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(Color(.systemBackground))
-                )
-                .shadow(radius: 20)
-                .padding(24)
+            // Dynamic Type 最大や小画面ではカードが画面高を超えるため、はみ出したぶんだけスクロールさせる
+            ScrollView(.vertical) {
+                AllowanceSheetView(viewModel: allowanceSheetVM)
+                    .frame(maxWidth: Constants.UI.FrameSize.dialogMaxWidth)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(Color(.systemBackground))
+                    )
+                    .shadow(radius: 20)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .padding(24)
         }
         .transition(.opacity)
+        // 背後のタブや一覧へフォーカスが抜けないようにする
+        .accessibilityAddTraits(.isModal)
     }
 
     var body: some View {

--- a/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
+++ b/Night-Core-Player/Features/Playlist/PlaylistDetailView.swift
@@ -85,6 +85,7 @@ struct PlaylistDetailView: View {
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
+                    .contentMargins(.bottom, Constants.UI.FrameSize.miniMusicPlayerContentInset, for: .scrollContent)
                     .background(Color(.systemBackground))
                     .navigationDestination(for: Song.self) { song in
                         Text(song.title)

--- a/Night-Core-Player/Features/Search/ArtistDetailView.swift
+++ b/Night-Core-Player/Features/Search/ArtistDetailView.swift
@@ -88,6 +88,7 @@ struct ArtistDetailView: View {
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
+                    .contentMargins(.bottom, Constants.UI.FrameSize.miniMusicPlayerContentInset, for: .scrollContent)
                     .background(Color(.systemBackground))
                 }
                 .padding(.horizontal)

--- a/Night-Core-Player/Features/Settings/SettingsPlaybackSpeedView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsPlaybackSpeedView.swift
@@ -64,6 +64,7 @@ struct SettingsPlaybackSpeedView: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        .contentMargins(.bottom, Constants.UI.FrameSize.miniMusicPlayerContentInset, for: .scrollContent)
         .background(Color(.systemBackground))
         .enableInjection()
     }

--- a/Night-Core-Player/Features/Settings/SettingsView.swift
+++ b/Night-Core-Player/Features/Settings/SettingsView.swift
@@ -128,18 +128,19 @@ struct SettingsView: View {
                 // 枠超過シートは曲が終わったときにだけ出るため、広告確認のために直接開く口を用意する
                 debugRow("枠超過シートを開く") { allowanceSheetVM.debugPresent() }
             } header: {
-                Text("デバッグ（Debug ビルドのみ）")
+                Text(verbatim: "デバッグ（Debug ビルドのみ）")
                     .font(.headline)
                     .foregroundColor(.primary)
                     .padding(.top, 8)
             }
         }
 
-        private func debugRow(_ title: LocalizedStringKey, action: @escaping () -> Void) -> some View {
+        /// 開発者だけが見る行のため、ローカライズせず日本語のまま出す
+        private func debugRow(_ title: String, action: @escaping () -> Void) -> some View {
             VStack(spacing: 0) {
                 Button(action: action) {
                     HStack {
-                        Text(title)
+                        Text(verbatim: title)
                             .font(.body)
                             .foregroundColor(.primary)
                         Spacer()

--- a/Night-Core-Player/Services/AllowanceEnforcer.swift
+++ b/Night-Core-Player/Services/AllowanceEnforcer.swift
@@ -17,9 +17,12 @@ enum AllowanceEvent: Sendable {
 protocol AllowanceEnforcer: Sendable {
     var events: AnyPublisher<AllowanceEvent, Never> { get }
     var isExhausted: Bool { get }
-    func tick(isPlaying: Bool, rate: Double, now: Date)
+    func tick(isPlaying: Bool, rate: Double, songID: String?, now: Date)
     func shouldStopAtSongBoundary() -> Bool
+    /// 猶予対象外の曲で倍速再生が始まった場合に true。曲末を待たず等速へ戻す
+    func shouldRevertToNormalRateNow() -> Bool
     func markStoppedAtSongEnd()
+    func markRevertedToNormalRate()
 }
 
 // MARK: - Impl
@@ -45,8 +48,15 @@ final class AllowanceEnforcerImpl: AllowanceEnforcer {
     /// entitlement == .exhausted の写し。残高そのものの状態を表し、停止予約とは独立している
     private var isBalanceExhausted = false
 
-    /// 曲境界での停止予約。「枯滅+再生中+倍速」を観測したときだけアームされる
-    private var pendingStopAtSongEnd = false
+    /// 曲末までの猶予を与えた曲のID。ADR-003の猶予は「残高が尽きた時点で鳴っていた曲」だけが対象で、
+    /// 別の曲に移った時点で猶予は終わる。Bool だけで持つと倍速/等速の切替で猶予を取り直せてしまう
+    private var graceSongID: String?
+
+    /// 枯渇後に猶予を1曲ぶん使ったか。残高が回復するまで再取得させない
+    private var hasUsedGrace = false
+
+    /// 猶予対象外の曲で倍速を検知した。曲末を待たず等速へ戻す
+    private var needsRevertToNormalRate = false
 
     init(
         allowanceService: AllowanceService,
@@ -58,13 +68,13 @@ final class AllowanceEnforcerImpl: AllowanceEnforcer {
 
     var isExhausted: Bool { isBalanceExhausted }
 
-    func tick(isPlaying: Bool, rate: Double, now: Date) {
+    func tick(isPlaying: Bool, rate: Double, songID: String?, now: Date) {
         // Proは消費もアームもしない。既存の停止予約があれば解除して即return
         guard !isProEntitled() else {
             // lastTickAtを進めないとPro期間ぶんが溜まり、Pro解除後の初回tickで一括消費される
             lastTickAt = now
             isBalanceExhausted = false
-            pendingStopAtSongEnd = false
+            clearGrace()
             return
         }
 
@@ -89,34 +99,57 @@ final class AllowanceEnforcerImpl: AllowanceEnforcer {
                 isBalanceExhausted = true
             } else {
                 isBalanceExhausted = false
-                // クリア条件: 残高回復時は曲境界での停止予約も解除する
-                pendingStopAtSongEnd = false
+                // クリア条件: 残高が戻れば猶予の使用履歴ごと解除し、次の枯渇でまた1曲ぶん与える
+                clearGrace()
+                hasUsedGrace = false
             }
         }
 
-        // クリア条件: 等速再生を観測したら停止予約を解除する。
-        // 素のApple Music再生（等速）は残高に関係なく一切止めないため
-        if isPlaying, rate == Constants.MusicPlayer.normalPlaybackRate {
-            pendingStopAtSongEnd = false
+        // 等速再生は残高に関係なく一切止めない。ただし猶予の紐付けは保持する
+        // （倍速→等速→倍速で猶予を取り直せてしまうため）
+        guard isPlaying, rate != Constants.MusicPlayer.normalPlaybackRate else { return }
+        guard isBalanceExhausted else { return }
+
+        // 猶予が有効な間は何もしない。別の曲へ移った場合の停止は曲境界停止が担当する
+        guard graceSongID == nil else { return }
+
+        if hasUsedGrace {
+            // 枯渇後の猶予は1曲まで。以降は倍速へ入れさせない
+            needsRevertToNormalRate = true
             return
         }
 
-        // アーム条件: 「枯滅+再生中+倍速」のときだけ。false→true遷移時に一度だけイベントを出す。
-        // 枯滅しているだけでは絶対にアームしない
-        if isBalanceExhausted, isPlaying, !pendingStopAtSongEnd {
-            pendingStopAtSongEnd = true
-            eventSubject.send(.exhaustedPendingSongEnd)
-        }
+        // アーム条件: 「枯渇+再生中+倍速」を初めて観測した曲だけに曲末までの猶予を与える
+        graceSongID = songID
+        hasUsedGrace = true
+        eventSubject.send(.exhaustedPendingSongEnd)
     }
 
     func shouldStopAtSongBoundary() -> Bool {
         // tickを経由せず曲境界判定が走っても、Proユーザーを止めない
-        !isProEntitled() && pendingStopAtSongEnd
+        !isProEntitled() && graceSongID != nil
+    }
+
+    func shouldRevertToNormalRateNow() -> Bool {
+        !isProEntitled() && needsRevertToNormalRate
     }
 
     func markStoppedAtSongEnd() {
-        guard pendingStopAtSongEnd else { return }
-        pendingStopAtSongEnd = false
+        guard graceSongID != nil else { return }
+        graceSongID = nil
         eventSubject.send(.stoppedAtSongEnd)
+    }
+
+    func markRevertedToNormalRate() {
+        guard needsRevertToNormalRate else { return }
+        needsRevertToNormalRate = false
+        eventSubject.send(.stoppedAtSongEnd)
+    }
+
+    // MARK: - Private
+
+    private func clearGrace() {
+        graceSongID = nil
+        needsRevertToNormalRate = false
     }
 }

--- a/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
+++ b/Night-Core-Player/Services/MusicPlayerServiceImpl.swift
@@ -446,8 +446,12 @@ public final class MusicPlayerServiceImpl: MusicPlayerService {
         allowanceEnforcer?.tick(
             isPlaying: player.playbackState == .playing,
             rate: currentPlaybackRate,
+            songID: song?.id.rawValue,
             now: timestamp
         )
+
+        // 猶予対象外の曲での倍速は曲末を待たず等速へ戻す（等速再生自体は止めない）
+        revertToNormalRateIfNeeded()
 
         let title = song?.title ?? item?.title ?? "-"
         let artist = song?.artistName ?? item?.artist ?? "-"
@@ -740,6 +744,16 @@ extension MusicPlayerServiceImpl {
 }
 
 private extension MusicPlayerServiceImpl {
+    /// 猶予を使い切った後の曲で倍速に入られた場合、曲末を待たず等速へ戻す。
+    /// 曲末停止は「残高が尽きた時点で鳴っていた曲」だけの猶予であり、別の曲には及ばない
+    func revertToNormalRateIfNeeded() {
+        guard let enforcer = allowanceEnforcer, enforcer.shouldRevertToNormalRateNow() else { return }
+        rateBeforeAllowanceStop = currentPlaybackRate
+        currentPlaybackRate = Constants.MusicPlayer.normalPlaybackRate
+        player.playbackRate = currentPlaybackRate
+        enforcer.markRevertedToNormalRate()
+    }
+
     /// 枯渇時は曲境界でのみ停止する。素の（等速）再生は制限しない
     func stopAtSongBoundaryIfNeeded(pausePlayer: Bool) -> Bool {
         guard let enforcer = allowanceEnforcer, enforcer.shouldStopAtSongBoundary() else { return false }

--- a/Night-Core-PlayerTests/Features/Allowance/AllowanceSheetViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Allowance/AllowanceSheetViewModelTests.swift
@@ -12,9 +12,11 @@ private final class AllowanceEnforcerStub: AllowanceEnforcer {
     var events: AnyPublisher<AllowanceEvent, Never> { eventSubject.eraseToAnyPublisher() }
     var isExhausted = false
 
-    func tick(isPlaying: Bool, rate: Double, now: Date) {}
+    func tick(isPlaying: Bool, rate: Double, songID: String?, now: Date) {}
     func shouldStopAtSongBoundary() -> Bool { false }
+    func shouldRevertToNormalRateNow() -> Bool { false }
     func markStoppedAtSongEnd() {}
+    func markRevertedToNormalRate() {}
 
     func send(_ event: AllowanceEvent) {
         eventSubject.send(event)
@@ -369,6 +371,37 @@ struct AllowanceSheetViewModelTests {
         await Self.waitUntil { storeMock.purchaseCallCount == 1 }
 
         // Then
+        #expect(vm.isPresented)
+    }
+
+    @Test("Pro購入: 商品を取得できない場合はエラーを表示しシートを閉じないこと")
+    func purchasePro_unavailable_showsError() async throws {
+        // Given: StoreKitから商品を取得できない状態
+        let (vm, enforcer, _, _, _) = Self.setUp(purchaseResult: .success(.unavailable))
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When
+        vm.purchasePro()
+        await Self.waitUntil { vm.errorMessage != nil }
+
+        // Then: 無反応にせず理由を伝え、シートは開いたまま
+        #expect(vm.errorMessage != nil)
+        #expect(vm.isPresented)
+    }
+
+    @Test("Pro購入: 処理中はユーザー操作で閉じられないこと")
+    func dismissByUser_whilePurchasing_keepsSheetOpen() async throws {
+        // Given: 購入処理を遅延させ、処理中の窓を作る
+        let (vm, enforcer, _, storeMock, _) = Self.setUp(purchaseResult: .success(.purchased))
+        storeMock.purchaseDelayMilliseconds = 500
+        enforcer.send(.stoppedAtSongEnd)
+
+        // When: 処理中に閉じようとする
+        vm.purchasePro()
+        await Self.waitUntil { vm.isPurchasing }
+        vm.dismissByUser()
+
+        // Then: 裏で処理だけ進み結果が見えなくなるのを防ぐため閉じない
         #expect(vm.isPresented)
     }
 

--- a/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
+++ b/Night-Core-PlayerTests/Features/Settings/SettingsViewModelTests.swift
@@ -163,6 +163,37 @@ struct SettingsViewModelTests {
         #expect(vm.errorMessage == nil)
     }
 
+    @Test("purchasePro: 商品を取得できない場合はエラーを表示すること")
+    func purchasePro_productUnavailable_showsError() async throws {
+        // Given: StoreKitから商品を取得できない状態
+        let storeMock = ProStoreServiceMock()
+        storeMock.purchaseResult = .success(.unavailable)
+        let (vm, _, _) = SettingsViewModelTests.setUp(proStore: storeMock)
+
+        // When
+        vm.purchasePro()
+        await SettingsViewModelTests.waitUntil { vm.errorMessage != nil }
+
+        // Then: 無反応にせず、取得できなかったことを伝える
+        #expect(vm.errorMessage != nil, "ユーザーのキャンセルと区別してエラーを出す")
+        #expect(!vm.isProEntitled)
+    }
+
+    @Test("purchasePro: ユーザーキャンセルではエラーを表示しないこと")
+    func purchasePro_cancelled_doesNotShowError() async throws {
+        // Given
+        let storeMock = ProStoreServiceMock()
+        storeMock.purchaseResult = .success(.cancelled)
+        let (vm, _, _) = SettingsViewModelTests.setUp(proStore: storeMock)
+
+        // When
+        vm.purchasePro()
+        await SettingsViewModelTests.waitUntil { !vm.isPurchasing }
+
+        // Then
+        #expect(vm.errorMessage == nil, "ユーザー自身の操作にはエラーを出さない")
+    }
+
     @Test("purchasePro: isPurchasing中の再呼び出しはpurchase()を実行しないこと")
     func purchasePro_whilePurchasing_skipsSecondCall() async throws {
         // Given: purchase()を遅延させ、処理中の窓を作る

--- a/Night-Core-PlayerTests/Services/AllowanceEnforcerTests.swift
+++ b/Night-Core-PlayerTests/Services/AllowanceEnforcerTests.swift
@@ -44,8 +44,8 @@ struct AllowanceEnforcerTests {
         let (enforcer, mock, _) = Self.makeEnforcer()
         let t0 = Self.base
         // When: 等速で2回tick
-        enforcer.tick(isPlaying: true, rate: 1.0, now: t0)
-        enforcer.tick(isPlaying: true, rate: 1.0, now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: true, rate: 1.0, songID: "S1", now: t0)
+        enforcer.tick(isPlaying: true, rate: 1.0, songID: "S1", now: t0.addingTimeInterval(10))
         // Then: consumeは呼ばれない
         #expect(mock.consumeArgs.isEmpty)
     }
@@ -56,8 +56,8 @@ struct AllowanceEnforcerTests {
         let (enforcer, mock, _) = Self.makeEnforcer()
         let t0 = Self.base
         // When: 初回tick（計測起点）→ 10秒後にtick
-        enforcer.tick(isPlaying: true, rate: 1.5, now: t0)
-        enforcer.tick(isPlaying: true, rate: 1.5, now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: true, rate: 1.5, songID: "S1", now: t0)
+        enforcer.tick(isPlaying: true, rate: 1.5, songID: "S1", now: t0.addingTimeInterval(10))
         // Then: 2回目のtickで10秒消費。初回は起点のみで消費しない
         #expect(mock.consumeArgs.count == 1)
         #expect(mock.consumeArgs.first?.seconds == 10)
@@ -67,8 +67,8 @@ struct AllowanceEnforcerTests {
     func tickPausedDoesNotConsume() {
         let (enforcer, mock, _) = Self.makeEnforcer()
         let t0 = Self.base
-        enforcer.tick(isPlaying: false, rate: 2.0, now: t0)
-        enforcer.tick(isPlaying: false, rate: 2.0, now: t0.addingTimeInterval(30))
+        enforcer.tick(isPlaying: false, rate: 2.0, songID: "S1", now: t0)
+        enforcer.tick(isPlaying: false, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(30))
         #expect(mock.consumeArgs.isEmpty)
     }
 
@@ -77,8 +77,8 @@ struct AllowanceEnforcerTests {
         let (enforcer, mock, _) = Self.makeEnforcer()
         let t0 = Self.base
         // When: バックグラウンド放置を想定した1時間後のtick
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(3600))
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(3600))
         // Then: 消費は60秒にクランプされる
         #expect(mock.consumeArgs.count == 1)
         #expect(mock.consumeArgs.first?.seconds == 60)
@@ -89,7 +89,7 @@ struct AllowanceEnforcerTests {
         let (enforcer, _, recorder) = Self.makeEnforcer(
             entitlement: .trial(endsAt: Self.base.addingTimeInterval(86400))
         )
-        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: Self.base)
         #expect(!enforcer.isExhausted)
         #expect(recorder.received.isEmpty)
     }
@@ -104,8 +104,8 @@ struct AllowanceEnforcerTests {
         )
         let t0 = Self.base
         // When: 倍速+再生中で複数回tick
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(10))
         // Then: 消費も停止予約のアームも行わない
         #expect(mock.consumeArgs.isEmpty)
         #expect(!enforcer.shouldStopAtSongBoundary())
@@ -121,14 +121,14 @@ struct AllowanceEnforcerTests {
             isProEntitled: { isPro }
         )
         let t0 = Self.base
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(10))
         #expect(enforcer.shouldStopAtSongBoundary())
         #expect(mock.consumeArgs.first?.seconds == 10)
         let consumeCountBeforePro = mock.consumeArgs.count
         // When: Proを購入して有効化
         isPro = true
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(20))
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(20))
         // Then: 停止予約が解除され、Pro化後のtickでは消費も再アームもされない
         #expect(!enforcer.shouldStopAtSongBoundary())
         #expect(mock.consumeArgs.count == consumeCountBeforePro)
@@ -141,7 +141,7 @@ struct AllowanceEnforcerTests {
     func exhaustionSetsBoundaryStop() {
         let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
         // When: 枯渇状態でtick
-        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: Self.base)
         // Then
         #expect(enforcer.isExhausted)
         #expect(enforcer.shouldStopAtSongBoundary())
@@ -153,9 +153,9 @@ struct AllowanceEnforcerTests {
         let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
         let t0 = Self.base
         // When: 枯渇したまま複数回tick
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
-        enforcer.tick(isPlaying: false, rate: 1.0, now: t0.addingTimeInterval(20))
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: false, rate: 1.0, songID: "S1", now: t0.addingTimeInterval(20))
         // Then: イベントは1回だけ
         #expect(recorder.received == [.exhaustedPendingSongEnd])
         #expect(enforcer.shouldStopAtSongBoundary())
@@ -165,10 +165,10 @@ struct AllowanceEnforcerTests {
     func recoveryResetsBoundaryStop() {
         let (enforcer, mock, recorder) = Self.makeEnforcer(entitlement: .exhausted)
         let t0 = Self.base
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
         // When: リワード広告等で残高が回復する
         mock.entitlementResult = .free(remaining: Constants.Allowance.rewardSeconds)
-        enforcer.tick(isPlaying: false, rate: 1.0, now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: false, rate: 1.0, songID: "S1", now: t0.addingTimeInterval(10))
         // Then: 停止対象が解除され、枯渇イベントは再発行されない
         #expect(!enforcer.isExhausted)
         #expect(!enforcer.shouldStopAtSongBoundary())
@@ -178,7 +178,7 @@ struct AllowanceEnforcerTests {
     @Test("markStoppedAtSongEndで停止予約がクリアされる")
     func markStoppedClearsPendingStop() {
         let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
-        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: Self.base)
         #expect(enforcer.shouldStopAtSongBoundary())
         // When: 曲境界での停止完了を通知
         enforcer.markStoppedAtSongEnd()
@@ -191,50 +191,108 @@ struct AllowanceEnforcerTests {
     func exhaustionDoesNotArmAtNormalRate() {
         let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
         // When: 枯渇したまま等速再生をtick
-        enforcer.tick(isPlaying: true, rate: 1.0, now: Self.base)
-        enforcer.tick(isPlaying: true, rate: 1.0, now: Self.base.addingTimeInterval(10))
+        enforcer.tick(isPlaying: true, rate: 1.0, songID: "S1", now: Self.base)
+        enforcer.tick(isPlaying: true, rate: 1.0, songID: "S1", now: Self.base.addingTimeInterval(10))
         // Then: 素のApple Music再生は止めないためアームしない
         #expect(enforcer.isExhausted)
         #expect(!enforcer.shouldStopAtSongBoundary())
         #expect(recorder.received.isEmpty)
     }
 
-    @Test("枯渇後に等速へ戻ると停止予約が解除される")
-    func returningToNormalRateClearsPendingStop() {
+    @Test("枯渇後に等速へ戻しても、同じ曲の猶予は保持される")
+    func returningToNormalRateKeepsGraceOnSameSong() {
         let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
         let t0 = Self.base
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
         #expect(enforcer.shouldStopAtSongBoundary())
         // When: 倍速のまま枯渇検知後、ユーザーが等速へ戻して再生継続
-        enforcer.tick(isPlaying: true, rate: 1.0, now: t0.addingTimeInterval(10))
-        // Then: 停止予約のみ解除され、残高は枯渇したまま
-        #expect(!enforcer.shouldStopAtSongBoundary())
+        enforcer.tick(isPlaying: true, rate: 1.0, songID: "S1", now: t0.addingTimeInterval(10))
+        // Then: 等速へ戻しても猶予は曲に紐付いたまま（解除すると倍速へ戻して猶予を取り直せる）
+        #expect(enforcer.shouldStopAtSongBoundary())
         #expect(enforcer.isExhausted)
         #expect(recorder.received == [.exhaustedPendingSongEnd])
     }
 
-    @Test("停止後に再度倍速へ上げると再アームされ、exhaustedPendingSongEndが2度目に発行される")
-    func rearmsWhenNightcoreResumesAfterStop() {
+    @Test("枯渇後、倍速と等速を往復しても猶予は1曲ぶんのまま増えない")
+    func togglingRateDoesNotRenewGrace() {
         let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
         let t0 = Self.base
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0)
+        // Given: S1で猶予を取得
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        // When: 等速へ戻してから再び倍速へ上げる（猶予の取り直しを狙う操作）
+        enforcer.tick(isPlaying: true, rate: 1.0, songID: "S1", now: t0.addingTimeInterval(10))
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(20))
+        // Then: 猶予は増えず、イベントも1度きり
+        #expect(enforcer.shouldStopAtSongBoundary())
+        #expect(!enforcer.shouldRevertToNormalRateNow())
+        #expect(recorder.received == [.exhaustedPendingSongEnd])
+    }
+
+    @Test("猶予を使い切った後、別の曲で倍速に入ると曲末を待たず等速へ戻す")
+    func revertsImmediatelyOnAnotherSong() {
+        let (enforcer, _, _) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        // Given: S1で猶予を使い、曲末で停止済み
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        enforcer.markStoppedAtSongEnd()
+        // When: 次の曲S2で倍速に入る
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S2", now: t0.addingTimeInterval(10))
+        // Then: 曲末までの猶予は与えず、即座に等速へ戻す
+        #expect(enforcer.shouldRevertToNormalRateNow())
+        #expect(!enforcer.shouldStopAtSongBoundary())
+    }
+
+    @Test("猶予中に別の曲へ移っても、停止は曲境界停止が担当し即時復帰は起こさない")
+    func songChangeDuringGraceIsHandledByBoundaryStop() {
+        let (enforcer, _, _) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        // When: 停止処理を経ずに次の曲へスキップして倍速のまま再生
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S2", now: t0.addingTimeInterval(10))
+        // Then: 曲境界停止が有効なまま。即時復帰と二重に発火させない
+        #expect(enforcer.shouldStopAtSongBoundary())
+        #expect(!enforcer.shouldRevertToNormalRateNow())
+    }
+
+    @Test("残高が回復すると猶予の使用履歴もリセットされる")
+    func graceIsRenewedAfterBalanceRecovers() {
+        let (enforcer, mock, _) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
+        enforcer.markStoppedAtSongEnd()
+        // When: リワードなどで残高が回復し、その後また枯渇する
+        mock.entitlementResult = .free(remaining: 600)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S2", now: t0.addingTimeInterval(10))
+        #expect(!enforcer.shouldRevertToNormalRateNow())
+        mock.entitlementResult = .exhausted
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S2", now: t0.addingTimeInterval(20))
+        // Then: 新しい曲に対して改めて曲末までの猶予が与えられる
+        #expect(enforcer.shouldStopAtSongBoundary())
+        #expect(!enforcer.shouldRevertToNormalRateNow())
+    }
+
+    @Test("停止後に同じ曲を再度倍速へ上げても、猶予は再取得できず等速へ戻される")
+    func doesNotRenewGraceWhenNightcoreResumesAfterStop() {
+        let (enforcer, _, recorder) = Self.makeEnforcer(entitlement: .exhausted)
+        let t0 = Self.base
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0)
         enforcer.markStoppedAtSongEnd()
         #expect(!enforcer.shouldStopAtSongBoundary())
         // When: 手動で再度倍速へ上げて再生
-        enforcer.tick(isPlaying: true, rate: 2.0, now: t0.addingTimeInterval(10))
-        // Then: 再アームされ、イベントは2回目に発行される
-        #expect(enforcer.shouldStopAtSongBoundary())
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: t0.addingTimeInterval(10))
+        // Then: 曲末までの猶予は与えず即座に等速へ戻す。枯渇後の猶予は残高が回復するまで1曲ぶん
+        #expect(!enforcer.shouldStopAtSongBoundary())
+        #expect(enforcer.shouldRevertToNormalRateNow())
         #expect(recorder.received == [
             .exhaustedPendingSongEnd,
-            .stoppedAtSongEnd,
-            .exhaustedPendingSongEnd
+            .stoppedAtSongEnd
         ])
     }
 
     @Test("isExhaustedは残高状態を表し、停止予約とは独立している")
     func isExhaustedIndependentFromPendingStop() {
         let (enforcer, _, _) = Self.makeEnforcer(entitlement: .exhausted)
-        enforcer.tick(isPlaying: true, rate: 2.0, now: Self.base)
+        enforcer.tick(isPlaying: true, rate: 2.0, songID: "S1", now: Self.base)
         // When: 曲境界での停止を完了させる
         enforcer.markStoppedAtSongEnd()
         // Then: 残高は枯渇のまま、停止予約だけが解除される

--- a/docs/adr/003-allowance-design.md
+++ b/docs/adr/003-allowance-design.md
@@ -39,9 +39,13 @@ Nightcore 変換（`playbackRate != 1.0`）にフリーミアム課金を導入�
 
 ### 4. 残高枯渇時は即停止せず、曲境界で止める
 
-`AllowanceEnforcer` は「残高0 かつ 倍速再生中」を検知した時点では再生を止めず、`pendingStopAtSongEnd` フラグを立てて `.exhaustedPendingSongEnd` イベントを発行するだけにする。実際の停止は、曲が自然に終わるタイミングで `MusicPlayerServiceImpl` 側が `shouldStopAtSongBoundary()` を確認して行う。
+`AllowanceEnforcer` は「残高0 かつ 倍速再生中」を検知した時点では再生を止めず、猶予を与えた曲のID（`graceSongID`）を記録して `.exhaustedPendingSongEnd` イベントを発行するだけにする。実際の停止は、曲が自然に終わるタイミングで `MusicPlayerServiceImpl` 側が `shouldStopAtSongBoundary()` を確認して行う。
 
 BGM として流している利用シーンを想定すると、曲の途中で無音になるより、その曲を最後まで聴かせてから止める方が体験を損なわない。
+
+猶予は「残高が尽きた時点で鳴っていた曲」1曲ぶんに限る。残高が回復するまで再取得できず、猶予を使い切ったあとに倍速へ変更した場合は曲末を待たず等速へ戻す（`shouldRevertToNormalRateNow()`）。等速は無料のため再生自体は止めない。
+
+猶予をフラグだけで持つと、等速へ戻した時点で解除され、倍速へ戻すことで曲ごとに猶予を取り直せてしまう。曲IDと「猶予を使ったか」の両方を持つのはこの回避を塞ぐためであり、実害を「残高が尽きた曲の残り時間」に限定するという本設計の前提そのものを守る条件になっている。
 
 ## Scope
 

--- a/docs/specs/ARCHITECTURE.md
+++ b/docs/specs/ARCHITECTURE.md
@@ -175,7 +175,7 @@ Night-Core-Player/
 | Service | 役割 | 永続化 |
 |---------|------|--------|
 | `AllowanceService` | `AllowanceSnapshot`（残高・トライアル終了日・リワード回数等）の読み書きと、日次リセット・トライアル判定などの状態遷移 | する（`AllowanceRepository` 経由で SwiftData） |
-| `AllowanceEnforcer` | `MusicPlayerServiceImpl` の再生 tick から呼ばれ、倍速再生時のみ経過時間を `AllowanceService.consume` に渡す。残高が尽きたら即停止せず、現在の曲が終わるまで再生を続けたうえで停止する（曲境界停止） | しない（メモリ上のフラグのみ） |
+| `AllowanceEnforcer` | `MusicPlayerServiceImpl` の再生 tick から呼ばれ、倍速再生時のみ経過時間を `AllowanceService.consume` に渡す。残高が尽きたら即停止せず、その時点で鳴っていた曲が終わるまで再生を続けたうえで停止する（曲境界停止）。猶予は残高が回復するまで1曲ぶんで、使い切ったあとの倍速は曲末を待たず等速へ戻す | しない（メモリ上の状態のみ） |
 | `ProStoreService` | StoreKit 2 で Pro（非消耗型 `MizuRyu.NightCorePlayer.pro`）を購入・復元し、`isProEntitled` を公開する。Pro ユーザーは `AllowanceEnforcer` の消費・停止の対象外 | StoreKit のトランザクション履歴に委譲 |
 
 **設計上の制約:** 残高ゲートは Nightcore 変換（`playbackRate != 1.0`）にのみ掛ける。Apple Music の素の等速再生は制限しない（MusicKit 利用規約上、等速再生を課金対象にできないため）。時計を過去に戻す操作への対策として `guardedNow = max(now, lastSeenAt)` を使い、残高の巻き戻りを防いでいる。背景は [ADR 003](../adr/003-allowance-design.md) を参照。
@@ -184,22 +184,23 @@ Night-Core-Player/
 
 ```
 MusicPlayerServiceImpl.tick()
-        │ isPlaying, rate, now
+        │ isPlaying, rate, songID, now
         ▼
 AllowanceEnforcer.tick()
         │ consume() → AllowanceService（残高更新）
-        │ 残高0 かつ 倍速再生中 → pendingStopAtSongEnd = true
+        │ 残高0 かつ 倍速再生中
+        │   ├ 猶予が未使用 → graceSongID = songID（その曲だけ曲末まで許可）
+        │   └ 猶予を使用済み → needsRevertToNormalRate = true
         ▼
-events: AnyPublisher<AllowanceEvent, Never>
-        │ .exhaustedPendingSongEnd
-        ▼
-AllowanceSheetViewModel（購読）
+        ├─ .exhaustedPendingSongEnd（猶予の開始。現状は購読者なし）
         │
-        ▼
-曲境界到達（MusicPlayerServiceImpl側でshouldStopAtSongBoundary()を確認）
-        │ 再生を停止 + markStoppedAtSongEnd()
-        ▼
-AllowanceSheetView（+30分 / Pro購入 / 閉じる）
+        ├─ 曲境界到達 → shouldStopAtSongBoundary() → 再生停止 + markStoppedAtSongEnd()
+        └─ 猶予切れで倍速 → shouldRevertToNormalRateNow() → 等速へ戻す + markRevertedToNormalRate()
+                                    │ .stoppedAtSongEnd
+                                    ▼
+                          AllowanceSheetViewModel（購読）
+                                    ▼
+                          AllowanceSheetView（+30分 / Pro購入 / 閉じる）
 ```
 
 ### 「速度」は2つの意味を持つ


### PR DESCRIPTION
本日の変更 (#98 #99 #100) に対して Codex による敵対的レビューを実施し、指摘のうち妥当なものを修正した。レビュー判定は **FAIL**、High 2件を含む10件の指摘。

## 修正した指摘

### High: 枯渇後の猶予が曲に紐付かず、倍速再生を繰り返せる

曲末までの猶予を `pendingStopAtSongEnd: Bool` で持っていたため、**等速へ戻すと猶予が解除され、倍速へ戻すことで曲ごとに猶予を取り直せた**。曲の終わり際に等速へ戻す操作を繰り返せば、枯渇後も実質無制限に倍速再生できる。

ADR-003 は「実害は残高が尽きた曲の残り時間だけ」を前提にしていたが、実装がその前提を満たしていなかった。

猶予を **`graceSongID`（残高が尽きた時点で鳴っていた曲のID）** に紐付け、`hasUsedGrace` で残高が回復するまで1曲ぶんに限定した。等速の観測では猶予を解除せず、猶予を使い切ったあとに倍速へ入れた場合は曲末を待たず等速へ戻す (`shouldRevertToNormalRateNow()`)。等速再生自体は従来どおり止めない。

**副次的な効果**: 猶予を使い切ったあとに倍速を試みると即座に `.stoppedAtSongEnd` が発行され枠超過ダイアログが出る。従来は曲が終わるまで無反応で、「残高0なのに再生できる」という違和感の一因だった。

### Medium: 広告視聴中・購入中でもダイアログを閉じられ、処理だけが継続する

背景タップと閉じるボタンが busy 状態を見ておらず、広告ロード中に閉じると数秒後に広告が突然表示される、購入失敗のエラーが閉じたダイアログに入って見えない、といった状態になっていた。広告中に Pro を、購入中に広告を開始することもできた。

ユーザー操作による dismiss を `dismissByUser()` として分離し、処理中は塞ぐ。購入成功後の自動クローズは内部の `close()` を使うため影響しない。

### Medium: overlay 化でモーダルとしての性質が失われていた

`.sheet` から `overlay` に変えた際、VoiceOver のフォーカスが背後へ抜ける、Dynamic Type 最大や小画面でカードが画面高を超えて操作できない、という問題が残っていた。`isModal` トレイトと `ScrollView` を追加した。見た目は変えていない。

### Medium: 詳細画面で下端余白が漏れ、ミニプレイヤーが最下行に被る

`contentMargins` の付与がタブ直下の3画面だけで、プレイリスト詳細・アーティスト詳細・再生速度設定に漏れていた。いずれもミニプレイヤーが表示される画面。

### Low: テスト不足・デバッグUIの表記

`.unavailable` の分岐テストを両 ViewModel に追加。デバッグ行を `Text(verbatim:)` にしてローカライズ対象外であることを明示。`.derivedDataRelease/` と `.DS_Store` を gitignore に追加。

## 修正しなかった指摘 (理由つき)

| 指摘 | 判断 |
|---|---|
| tick が60秒以上欠落すると過少消費 | バックグラウンド再生 (audio) が有効で 0.5秒 Timer は動き続けるため、クランプが効く場面は限定的。再生位置ベースの計測への作り替えは影響が大きく、別途検討したい |
| 残高0時点でユーザーに通知がない | 非モーダルバナーの追加は体験の変更にあたるため提案に留める。上記 High の修正で、猶予を使い切ったあとは即座にダイアログが出るようになった |
| `AllowanceService` を `@Observable` にすべき | 設計変更の規模が大きい。再生中に設定画面を開きっぱなしだと表示が更新されない問題は残る |
| `debugReset` が Enforcer の状態を残す | `updateSnapshot` は必ず tick を先に呼ぶため、曲境界判定より前に状態が更新される。実害を再現できず、coordinator の追加は過剰と判断 |

## 確認

- `make test` → **全通過** (EXIT=0、失敗0、42秒完走)
- 実機ビルド (iPhone 13 / iOS 26.6) 成功・インストール済み
- `swiftlint` → 変更ファイルで違反0 (リポジトリ全体の既存7件は本PR範囲外)
- ADR-003 と ARCHITECTURE.md のイベント図を実装に追随させた

## 未検証

抜け穴修正の実機での挙動確認 (残高を枯渇させ、倍速と等速を往復して猶予が再取得されないこと) は未実施。ユニットテストでは網羅している。