### PR TITLE
chore: push時のセキュリティゲートとworkflowの検査を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,25 @@ permissions:
   contents: read
 
 jobs:
+  # workflow 自体の検査。数秒で終わるため重い test とは別 job にして並列に走らせる。
+  # コード・秘密・依存の検査は pre-push が担うので、ここでは workflow だけを見る。
+  workflows:
+    name: Workflow Lint
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '"macos-15"') }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: actionlint
+        run: actionlint -color
+
+      - name: zizmor
+        run: zizmor --persona=regular .github/workflows
+
   test:
     name: Build & Test
     runs-on: ${{ fromJSON(vars.CI_RUNNER || '"macos-15"') }}
@@ -30,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Show environment
         run: |

--- a/.github/workflows/demo-catalog.yml
+++ b/.github/workflows/demo-catalog.yml
@@ -36,7 +36,7 @@ jobs:
       # 索引生成スクリプト（main 側）。pr-assets の中身はここには入らない。
       # persist-credentials: false — このジョブはリポジトリへの書き込みトークンを持つ唯一の
       # ジョブなので、スクリプトを走らせる作業ツリーには認証情報を残さない。
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
       # 走らせないため。build-demo-catalog.ts は node 標準 API だけで書かれており、
       # Node 24 の型ストリップで .ts を直接実行できる（実測済み）。
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           # setup-node v5 は package-manager-cache が既定で有効で、package.json の
@@ -96,7 +96,7 @@ jobs:
       # token が read-only になり push は失敗する。private リポジトリで fork 運用は無い前提）。
       - name: Checkout pr-assets branch
         if: steps.assets-branch.outputs.exists == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: pr-assets
           path: pr-assets

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,10 +8,9 @@ on:
       - "privacy-policy/**"
   workflow_dispatch:
 
+# 既定は読み取りのみ。書き込みは実際に必要な deploy job だけに降ろす
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -25,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -49,6 +50,9 @@ jobs:
     name: Deploy GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.4.app

--- a/.semgrep/rules.yml
+++ b/.semgrep/rules.yml
@@ -1,0 +1,46 @@
+# pre-push で走らせるローカルルール。ネットワーク取得なしで完結させるため registry は参照しない。
+# 網羅は目的ではなく、このアプリで実際に起こりうる混入だけを止める。
+rules:
+  - id: hardcoded-credential
+    languages: [swift]
+    severity: ERROR
+    message: >-
+      認証情報がソースに直書きされている。バイナリから抽出できるため、
+      Keychain か実行時取得に移すこと。
+    patterns:
+      - pattern-regex: >-
+          (?i)(secret|password|passwd|apikey|api_key|access_token|private_key|client_secret)\s*(:\s*String)?\s*=\s*"[^"]{8,}"
+      # 空文字・プレースホルダ・テスト値は対象外
+      - pattern-not-regex: >-
+          (?i)=\s*"(|YOUR_[A-Z_]+|TODO|dummy|example|placeholder|xxx+)"
+
+  - id: insecure-http-url
+    languages: [swift]
+    severity: ERROR
+    message: >-
+      平文HTTPのURLを使っている。ATS の例外設定が必要になり審査でも指摘される。
+      https に変えること。
+    patterns:
+      - pattern-regex: '"http://(?!localhost|127\.0\.0\.1)[^"]+"'
+
+  - id: sensitive-data-in-userdefaults
+    languages: [swift]
+    severity: WARNING
+    message: >-
+      UserDefaults は平文で保存され、バックアップにも含まれる。
+      認証情報や購入状態の正典を置かないこと（Pro 権限は StoreKit のトランザクションが正典）。
+    patterns:
+      - pattern-regex: >-
+          (?i)UserDefaults[^\n]*\.set\([^)]*(token|secret|password|receipt|entitle)
+
+  - id: weak-hash-algorithm
+    languages: [swift]
+    severity: WARNING
+    message: >-
+      MD5 / SHA1 は衝突耐性がない。整合性検証や識別子生成に使うなら SHA256 以上にすること。
+    patterns:
+      - pattern-either:
+          - pattern: Insecure.MD5.$F(...)
+          - pattern: Insecure.SHA1.$F(...)
+          - pattern-regex: \bCC_MD5\s*\(
+          - pattern-regex: \bCC_SHA1\s*\(

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,21 @@ pre-commit:
     gitleaks:
       run: gitleaks protect --staged -v
 
+# push を関門にする。commit 時は軽い検査だけを置き、重い検査はここへ寄せる。
+# 速度が要件のため semgrep はローカルルールのみ（registry を引かない）で変更ファイルに限定する。
+pre-push:
+  parallel: true
+  commands:
+    gitleaks-history:
+      # staged 差分ではなく全履歴。public 化した時点で過去のコミットも露出するため
+      run: gitleaks detect --source . --no-banner --redact
+    semgrep:
+      glob: "*.swift"
+      run: semgrep scan --config .semgrep/rules.yml --error --quiet --metrics=off {push_files}
+    trivy-deps:
+      # SPM の解決済み依存に既知脆弱性がないか
+      run: trivy fs --scanners vuln --exit-code 1 --quiet --skip-version-check Night-Core-Player.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
 commit-msg:
   commands:
     conventional-commit:


### PR DESCRIPTION
public 化に備えて、秘密・コード・依存・workflow の4面を検査する仕組みを入れる。

## 方針

CI を遅くしないため、**コードの検査は push 時のローカル実行に寄せ**、GitHub Actions では workflow 自体の検査だけを別 job で並列に走らせる。同じ面を二重に検査しない。

## pre-push (lefthook, 並列実行) — 実測 3 秒

| 検査 | 対象 | 実測 | 理由 |
|---|---|---|---|
| gitleaks | **全履歴** | 0.9 秒 | public 化すると過去のコミットも露出するため、staged 差分では意味がない |
| semgrep | 変更した Swift ファイル | 3.8 秒 (全量時) | ローカルルールのみ。registry を引かないのでオフラインで完結する |
| trivy | `Package.resolved` | 1.0 秒 | SPM の解決済み依存に既知脆弱性がないか |

semgrep のルール (`.semgrep/rules.yml`) は、このアプリで実際に起こりうる4つに絞った。網羅は目的にしない。

- 認証情報の直書き (プレースホルダは除外)
- 平文 HTTP URL (ATS 例外が必要になり審査でも指摘される)
- UserDefaults への機微データ保存 (Pro 権限の正典は StoreKit のトランザクション)
- 脆弱なハッシュ (MD5 / SHA1)

意図的な違反ファイルで3ルールとも検出すること、`YOUR_API_KEY` のようなプレースホルダを誤検出しないことを確認済み。

## ローカル CI — Workflow Lint job を新設

`actionlint` (構文) と `zizmor` (Actions のセキュリティ) を、既存の Build & Test (30分想定) とは**別 job**で走らせる。数秒で終わるためビルドを待たせない。`CI_RUNNER` 変数に従うので self-hosted でも動く。

## zizmor が検出した実在の問題を解消

導入時点で **14 件 (high 5 / medium 4)** 検出された。すべて修正済みで、現在は `No findings to report`。

| 種別 | 件数 | 修正内容 |
|---|---|---|
| `unpinned-uses` | 3 | `demo-catalog.yml` の Actions を SHA 固定。タグは書き換え可能で供給網リスクになる |
| `excessive-permissions` | 2 | `pages.yml` の `pages: write` / `id-token: write` を deploy job だけに降ろす |
| `artipacked` | 4 | checkout に `persist-credentials: false` を追加し、認証情報を作業ツリーに残さない |

SHA 固定は挙動を変えないよう、現在使っている v5 系のコミット SHA に固定した (v7 への更新はしていない)。

## 確認

- `actionlint` → 終了コード 0
- `zizmor --persona=regular` → **No findings to report**
- 実際の push で pre-push ゲートが動作、**3 秒で完了**
- gitleaks 全履歴 (171 コミット) → リーク 0
- trivy → 脆弱性 0

## 補足

ツール本体 (semgrep / actionlint / zizmor / trivy) は `~/dotfiles` の Nix 管理に追加済み。このリポジトリ側は実行設定のみを持つ。