### PR TITLE
feat: サポートページを追加しストアのサポートURLを差し替える (#59)

### DIFF
--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/MizuRyu/NightCorePlayer/issues
+https://mizuryu.github.io/NightCorePlayer/support/

--- a/fastlane/metadata/ja/support_url.txt
+++ b/fastlane/metadata/ja/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/MizuRyu/NightCorePlayer/issues
+https://mizuryu.github.io/NightCorePlayer/support/

--- a/privacy-policy/docs/index.md
+++ b/privacy-policy/docs/index.md
@@ -4,3 +4,4 @@ NightCore Player の利用規約とプライバシーポリシーを公開して
 
 - [利用規約](terms.md)
 - [プライバシーポリシー](privacy.md)
+- [サポート / Support](support.md)

--- a/privacy-policy/docs/support.md
+++ b/privacy-policy/docs/support.md
@@ -1,0 +1,55 @@
+# サポート / Support
+
+NightCore Player についてのお問い合わせ、不具合の報告、機能のご要望はこちらからお送りください。
+
+[お問い合わせフォーム / Contact form](https://forms.gle/p5CTaqH4omaJiEFx6)
+
+アプリ内の「設定 → お問い合わせ」からも同じフォームを開けます。
+
+---
+
+## よくある質問
+
+### 倍速再生ができない
+
+Apple Music の有効なサブスクリプションが必要です。等速での再生は無料でご利用いただけますが、倍速再生（NightCore 変換）には再生時間の残高が必要です。
+
+残高は「設定 → 今日の残り再生時間」で確認できます。
+
+### 再生が曲の途中で止まった
+
+再生時間の残高がなくなると、再生中の曲が終わった時点で倍速再生を停止します。曲の途中で音が切れることはありません。
+
+停止後は、広告を視聴して +30 分を追加するか、Pro を購入すると再開できます。等速での再生は残高に関係なく続けられます。
+
+### 購入した Pro が反映されない
+
+「設定 → 購入を復元」をお試しください。それでも反映されない場合は、上記のフォームからご連絡ください。
+
+### 楽曲が検索できない
+
+Apple Music へのアクセスを許可しているかご確認ください。iOS の「設定 → プライバシーとセキュリティ → メディアと Apple Music」から変更できます。
+
+---
+
+## Support (English)
+
+For questions, bug reports, or feature requests, please use the [contact form](https://forms.gle/p5CTaqH4omaJiEFx6).
+
+You can also reach the same form from **Settings → Feedback & Contact** in the app.
+
+### Playback speed control is unavailable
+
+An active Apple Music subscription is required. Normal-speed playback is free, while speeding up a track (NightCore conversion) consumes your daily playback time.
+
+Check your remaining time under **Settings → Today's Remaining Playback Time**.
+
+### Playback stopped between tracks
+
+When your playback time runs out, the app finishes the current track before stopping the sped-up playback — it never cuts off mid-song.
+
+Watch a video to add 30 minutes, or purchase Pro for unlimited playback. Normal-speed playback continues regardless.
+
+### A Pro purchase is not reflected
+
+Try **Settings → Restore Purchases**. If it still does not appear, please contact us through the form above.

--- a/privacy-policy/mkdocs.yml
+++ b/privacy-policy/mkdocs.yml
@@ -13,3 +13,4 @@ nav:
   - Home: index.md
   - 利用規約: terms.md
   - プライバシーポリシー: privacy.md
+  - サポート: support.md


### PR DESCRIPTION
Closes #59

## 背景

リポジトリの private 化により GitHub Pages が停止し、ストアに登録するプライバシーポリシー URL が **404 になっていた** (実測確認済み)。また、サポート URL は GitHub Issues を指しており、private では第三者が到達できないうえ、public でも審査で窓口として不適切と見なされうる。

| 用途 | 変更前 | 変更後 |
|---|---|---|
| プライバシーポリシー | `.../NightCorePlayer/privacy/` (404) | 同 URL (public 化 + Pages 有効化で復旧) |
| サポート | `github.com/MizuRyu/NightCorePlayer/issues` | `.../NightCorePlayer/support/` |

## 変更内容

公開中の MkDocs サイトにサポートページを追加した。

- 問い合わせ先はアプリ内の「設定 → お問い合わせ」と同じ Google フォームに統一
- 残高の仕組み、曲末での停止挙動、Pro の復元、Apple Music の権限など、問い合わせが想定される項目を FAQ として日英で記載
- `mkdocs.yml` の nav と `index.md` からも辿れるようにした

## 確認

- `mkdocs build` が通り、`support/` が生成されることを確認
- リポジトリを public 化し、GitHub Pages を `build_type: workflow` で有効化済み

マージ後に Pages のデプロイが走るため、実際の URL 到達は反映後に確認する。