### PR TITLE
docs: TestFlight配布と審査提出の手順を追加 (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ docs/adr/                   # Architecture Decision Record
 | [TESTING-STRATEGY.md](docs/specs/TESTING-STRATEGY.md) | テスト方針・Mock 規約 |
 | [PROJECT-RULES.md](docs/specs/PROJECT-RULES.md) | 運用ルール |
 | [PROJECT-STRUCTURE.md](docs/specs/PROJECT-STRUCTURE.md) | ディレクトリ構造 |
+| [RELEASE.md](docs/specs/RELEASE.md) | TestFlight 配布・審査提出の手順 |
+| [APP-REVIEW-NOTES.md](docs/specs/APP-REVIEW-NOTES.md) | 審査へ提出する説明文と根拠 |
 | [docs/adr/](docs/adr/) | 設計判断の記録（ADR） |
 | [docs/conventions/pr-assets.md](docs/conventions/pr-assets.md) | PR 成果物（スクショ・デモ動画）の置き場 |
 

--- a/docs/specs/RELEASE.md
+++ b/docs/specs/RELEASE.md
@@ -1,0 +1,112 @@
+# リリース手順
+
+TestFlight への配布から App Store 審査提出までの手順。
+審査ノートの本文とチェックリストは [APP-REVIEW-NOTES.md](APP-REVIEW-NOTES.md) を参照。
+
+## 前提: App Store Connect API キー
+
+`fastlane beta` / `fastlane submit_for_review` は App Store Connect API キーを使う。
+Apple ID とパスワードによる認証は 2FA の対話が入るため使わない。
+
+### キーの発行
+
+1. App Store Connect → **ユーザとアクセス** → **統合** → **App Store Connect API**
+2. **チームキー**タブで「+」を押し、アクセス権に **App Manager** を指定して生成
+3. `AuthKey_XXXXXXXXXX.p8` をダウンロード（**再ダウンロードできない**ため必ず保管する）
+4. 同じ画面から **Key ID** と **Issuer ID** を控える
+
+### 環境変数の設定
+
+`.p8` は base64 に変換して渡す。Fastfile が `is_key_content_base64: true` で受け取る。
+
+```sh
+export ASC_KEY_ID="発行した Key ID"
+export ASC_ISSUER_ID="発行した Issuer ID"
+export ASC_KEY_CONTENT="$(base64 -i ~/path/to/AuthKey_XXXXXXXXXX.p8)"
+export APPLE_ID="Apple ID のメールアドレス"
+```
+
+`.p8` と各 ID は秘密情報のため、リポジトリに置かない。
+`.gitignore` は `*.p8` と `.env` を除外済みだが、そもそも置かない運用にする。
+
+## TestFlight へ配布 (#76)
+
+```sh
+bundle exec fastlane beta
+```
+
+`beta` は内部で `build` を実行してから `pilot` でアップロードする。
+配布先は Internal グループ。リリースノートは `RELEASE_NOTE` で上書きできる。
+
+```sh
+RELEASE_NOTE="残高まわりの修正を確認" bundle exec fastlane beta
+```
+
+### アップロード前の自己検証
+
+認証を通す前に、アーカイブが成立するかだけ確認できる。
+
+```sh
+xcodebuild -project Night-Core-Player.xcodeproj \
+  -scheme Night-Core-Player \
+  -configuration Release \
+  -destination 'generic/platform=iOS' \
+  -archivePath ./build/NightCorePlayer.xcarchive \
+  -allowProvisioningUpdates archive
+```
+
+成果物の確認ポイント。
+
+```sh
+P=build/NightCorePlayer.xcarchive/Products/Applications/Night-Core-Player.app
+
+codesign -dv "$P"                                        # 署名と Team ID
+/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$P/Info.plist"
+ls "$P/PrivacyInfo.xcprivacy"                            # AdMob / ATT に必須
+
+# デバッグ機能が Release に漏れていないこと
+strings "$P/Night-Core-Player" | grep -c debugExhaust    # 0 であること
+```
+
+## TestFlight で確認すること (#76)
+
+デバッグ入口は Release ビルドに含まれないため、通常の経路でしか到達できない。
+
+- [ ] リワード広告が**本番ユニット ID**で表示される（Debug はテスト ID のため別物）
+- [ ] 広告視聴後に +30 分が付与され、残り再生時間の表示に反映される
+- [ ] 視聴後に再生が自動復帰する
+- [ ] 残高が尽きたとき、曲の途中で切れず曲末で停止する
+- [ ] Pro を購入でき、購入後に無制限になる
+- [ ] 「購入を復元」が機能する
+- [ ] リワード累計 5 回で Pro 訴求が 1 回だけ出る
+
+残高の枯渇には 1 日分の無料枠 3600 秒を消費する必要がある。
+トライアル中（初回起動から 7 日間）は枯渇しないため、テスターに配る前に
+トライアルが明けた端末を用意するか、消費してから確認する。
+
+## 審査提出 (#77)
+
+初回の非消耗型アプリ内課金は、**アプリのバージョンと同時に提出する**必要がある。
+
+1. App Store Connect → アプリ内課金 → Pro → **「審査用に追加」**
+2. 課金の「審査に関する情報」にスクリーンショットを添付
+   （`scripts/` で生成したダイアログのスクリーンショット）
+3. バージョン情報にスクリーンショット・説明文・URL を設定
+   （メタデータは `fastlane/metadata/` にあり `deliver` で反映できる）
+4. App Review 情報のメモに [APP-REVIEW-NOTES.md](APP-REVIEW-NOTES.md) の本文を貼る
+5. 提出
+
+```sh
+bundle exec fastlane submit_for_review
+```
+
+## 段階的公開 (#78)
+
+審査通過後、App Store Connect のバージョンリリース設定で
+**段階的リリース**を有効にしてから公開する。
+
+公開後に監視する項目。
+
+- クラッシュ率（Xcode Organizer / App Store Connect のメトリクス）
+- リワード広告の表示・完了率（AdMob 管理画面）
+- Pro の購入数と復元の失敗（App Store Connect の売上とトレンド）


### PR DESCRIPTION
#76 の準備。TestFlight への配布から審査提出、段階的公開までの手順をまとめる。

## 背景

`fastlane beta` は App Store Connect API キーを要求するが、環境変数が未設定で実行できない状態だった。キーの発行方法と設定手順を残す。

## Release アーカイブの自己検証結果

認証を通す前に、アーカイブが成立するかを実測した。

| 項目 | 結果 |
|---|---|
| `xcodebuild archive` | **ARCHIVE SUCCEEDED** |
| 署名 | `MizuRyu.Night-Core-Player` / Team `ND9MTVXZRQ` |
| バージョン | 1.0 (build 1) |
| `PrivacyInfo.xcprivacy` | 同梱済み (AdMob / ATT に必須) |
| `NSUserTrackingUsageDescription` | 設定済み |
| `GADApplicationIdentifier` | 設定済み |
| `NSAppleMusicUsageDescription` | 設定済み |

**デバッグ入口が Release バイナリに含まれていないことを実バイナリで確認した。**
`strings` で `debugExhaust` / `debugReset` / `debugPresent` および日本語ラベルを探したが、いずれもヒットしない。`#if DEBUG` が正しく機能している。

つまり**認証情報さえ設定すれば、そのまま TestFlight に上げられる状態**にある。

## 内容

- App Store Connect API キーの発行手順 (チームキー / App Manager 権限)
- `.p8` を base64 で環境変数に渡す方法
- `fastlane beta` の実行と `RELEASE_NOTE` の指定
- 認証前にアーカイブだけ検証する手順
- TestFlight でしか確認できない項目のチェックリスト
- 審査提出 (#77) と段階的公開 (#78) の流れ

## TestFlight でないと確認できないこと

Debug ビルドはテスト広告ユニットを使うため、**本番の広告配信は TestFlight でしか確認できない**。またデバッグ入口が Release に含まれないため、残高の枯渇には無料枠 3600 秒の消費が必要になる。この制約も明記した。
